### PR TITLE
feat: scaffold frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
-# trakos-web
-Frontend React
+# ClimaTrak Frontend
+
+This repository contains the React front-end for ClimaTrak.
+
+## Development
+
+Install dependencies and start the dev server:
+
+```bash
+pnpm install
+pnpm dev
+```
+
+The application will be available at http://localhost:5173 showing **Hello ClimaTrak**.
+
+### Formatting and Linting
+
+Run the linter and formatter:
+
+```bash
+pnpm lint
+pnpm format
+pnpm format:check
+```
+

--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -1,0 +1,13 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+    node: true,
+  },
+  extends: ['airbnb-typescript', 'airbnb/hooks', 'prettier'],
+  parserOptions: {
+    project: './tsconfig.json',
+  },
+  rules: {},
+};
+

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}
+

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ClimaTrak</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "frontend",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "lint": "eslint --ext .ts,.tsx src",
+    "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,css,md}\"",
+    "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,css,md}\""
+  },
+  "dependencies": {
+    "@mantine/core": "^7.0.0",
+    "@mantine/form": "^7.0.0",
+    "@mantine/hooks": "^7.0.0",
+    "@tanstack/react-query": "^5.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0",
+    "zustand": "^4.4.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.14",
+    "eslint": "^8.56.0",
+    "eslint-config-airbnb-typescript": "^17.1.0",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-jsx-a11y": "^6.7.1",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "postcss": "^8.4.31",
+    "prettier": "^3.1.0",
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5.3.3",
+    "vite": "^4.5.0"
+  }
+}
+

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,7 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,4 @@
+import App from './presentation/App';
+
+export default App;
+

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,4 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);
+

--- a/frontend/src/presentation/App.tsx
+++ b/frontend/src/presentation/App.tsx
@@ -1,0 +1,4 @@
+const App = () => <h1>Hello ClimaTrak</h1>;
+
+export default App;
+

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,14 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: { DEFAULT: '#002d2b' },
+        secondary: { 100: '#00fff4', 500: '#00968f' },
+      },
+    },
+  },
+  plugins: [],
+};
+

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}
+

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}
+

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "traknor-root",
+  "private": true,
+  "workspaces": ["frontend"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - 'frontend'
+


### PR DESCRIPTION
## Summary
- set up pnpm workspace and Vite React project under `frontend`
- add ESLint and Prettier configs
- configure Tailwind with custom colors
- show `Hello ClimaTrak` page
- update README with dev instructions

## Testing
- `pnpm install` *(fails: ERR_PNPM_FETCH_403)*
- `pnpm --filter frontend lint` *(fails: node_modules missing)*
- `pnpm --filter frontend format:check` *(fails: node_modules missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68560e8524ac832c91b0c1f9cc2c7d77