### PR TITLE
feat: theme provider setup

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -1,0 +1,9 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+const config: StorybookConfig = {
+  stories: ['../src/**/*.stories.tsx'],
+  addons: ['@storybook/addon-essentials'],
+  framework: '@storybook/react-vite',
+};
+
+export default config;

--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -1,0 +1,15 @@
+import type { Preview } from '@storybook/react';
+import React from 'react';
+import ClimaTrakThemeProvider from '../src/providers/ClimaTrakThemeProvider';
+
+const preview: Preview = {
+  decorators: [
+    (Story) => (
+      <ClimaTrakThemeProvider>
+        <Story />
+      </ClimaTrakThemeProvider>
+    ),
+  ],
+};
+
+export default preview;

--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:5173',
+    supportFile: false,
+  },
+});

--- a/frontend/cypress/e2e/theme.cy.ts
+++ b/frontend/cypress/e2e/theme.cy.ts
@@ -1,0 +1,7 @@
+describe('theme toggle', () => {
+  it('toggles dark and light mode', () => {
+    cy.visit('/');
+    cy.contains('mode').click();
+    cy.contains('mode');
+  });
+});

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+};

--- a/frontend/jest.setup.ts
+++ b/frontend/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,10 @@
     "build": "tsc && vite build",
     "lint": "eslint --ext .ts,.tsx src",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,css,md}\"",
-    "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,css,md}\""
+    "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,css,md}\"",
+    "test": "jest",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
   },
   "dependencies": {
     "@mantine/core": "^7.0.0",
@@ -32,7 +35,12 @@
     "prettier": "^3.1.0",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.3.3",
-    "vite": "^4.5.0"
+    "vite": "^4.5.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "storybook": "^7.6.0",
+    "cypress": "^13.6.0"
   }
 }
-

--- a/frontend/src/DesignTokens.stories.tsx
+++ b/frontend/src/DesignTokens.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta } from '@storybook/react';
+import useTokens from './hooks/useTokens';
+
+const meta: Meta = {
+  title: 'Design Tokens',
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+
+export const Colors = () => {
+  const { colors } = useTokens();
+  return (
+    <div>
+      {Object.entries(colors).map(([key, value]) =>
+        typeof value === 'string' ? (
+          <div key={key} style={{ background: value, padding: 10 }}>
+            {key}: {value}
+          </div>
+        ) : (
+          Object.entries(value).map(([shade, hex]) => (
+            <div key={shade} style={{ background: hex, padding: 10 }}>
+              {key}-{shade}: {hex}
+            </div>
+          ))
+        ),
+      )}
+    </div>
+  );
+};

--- a/frontend/src/hooks/useTokens.ts
+++ b/frontend/src/hooks/useTokens.ts
@@ -1,0 +1,5 @@
+import { colors, typography, spacing } from '../styles/tokens';
+
+const useTokens = () => ({ colors, typography, spacing });
+
+export default useTokens;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import ClimaTrakThemeProvider from './providers/ClimaTrakThemeProvider';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <ClimaTrakThemeProvider>
+      <App />
+    </ClimaTrakThemeProvider>
   </React.StrictMode>,
 );
-

--- a/frontend/src/presentation/components/Button.stories.tsx
+++ b/frontend/src/presentation/components/Button.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useMantineColorScheme, Button } from '@mantine/core';
+
+const meta: Meta = {
+  title: 'Components/Button',
+  component: Button,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Button>;
+
+export const Default: Story = {
+  render: () => {
+    const { colorScheme, toggleColorScheme } = useMantineColorScheme();
+    return (
+      <div>
+        <Button onClick={() => toggleColorScheme()}>{colorScheme} mode</Button>
+      </div>
+    );
+  },
+};

--- a/frontend/src/presentation/components/Button.test.tsx
+++ b/frontend/src/presentation/components/Button.test.tsx
@@ -1,0 +1,12 @@
+import { render } from '@testing-library/react';
+import Button from './Button';
+import ClimaTrakThemeProvider from '../../providers/ClimaTrakThemeProvider';
+
+test('button renders correctly', () => {
+  const { container } = render(
+    <ClimaTrakThemeProvider>
+      <Button>Test</Button>
+    </ClimaTrakThemeProvider>,
+  );
+  expect(container).toMatchSnapshot();
+});

--- a/frontend/src/presentation/components/Button.tsx
+++ b/frontend/src/presentation/components/Button.tsx
@@ -1,0 +1,5 @@
+import { Button as MantineButton, ButtonProps } from '@mantine/core';
+
+const Button = (props: ButtonProps) => <MantineButton {...props} />;
+
+export default Button;

--- a/frontend/src/providers/ClimaTrakThemeProvider.tsx
+++ b/frontend/src/providers/ClimaTrakThemeProvider.tsx
@@ -1,0 +1,46 @@
+import { ReactNode, useState } from 'react';
+import {
+  MantineProvider,
+  ColorSchemeProvider,
+  ColorScheme,
+  createTheme,
+} from '@mantine/core';
+import { colors } from '../styles/tokens';
+
+interface Props {
+  children: ReactNode;
+}
+
+const theme = createTheme({
+  primaryColor: 'brand',
+  colors: {
+    brand: Array(10).fill(colors.primary),
+  },
+  defaultRadius: 'xl',
+  fontFamily: 'sans-serif',
+});
+
+const ClimaTrakThemeProvider = ({ children }: Props) => {
+  const [colorScheme, setColorScheme] = useState<ColorScheme>('light');
+
+  const toggleColorScheme = (value?: ColorScheme) =>
+    setColorScheme(value || (colorScheme === 'dark' ? 'light' : 'dark'));
+
+  return (
+    <ColorSchemeProvider
+      colorScheme={colorScheme}
+      toggleColorScheme={toggleColorScheme}
+    >
+      <MantineProvider
+        theme={theme}
+        withGlobalStyles
+        withNormalizeCSS
+        colorScheme={colorScheme}
+      >
+        {children}
+      </MantineProvider>
+    </ColorSchemeProvider>
+  );
+};
+
+export default ClimaTrakThemeProvider;

--- a/frontend/src/styles/tokens.ts
+++ b/frontend/src/styles/tokens.ts
@@ -1,0 +1,27 @@
+export const colors = {
+  primary: '#002d2b',
+  secondary: '#00968f',
+  accent: '#00fff4',
+  gray: {
+    50: '#f9fafb',
+    100: '#f3f4f6',
+    900: '#111827',
+  },
+};
+
+export const typography = {
+  display96: '96px',
+  heading48: '48px',
+  heading32: '32px',
+  heading24: '24px',
+  body16: '16px',
+  caption12: '12px',
+};
+
+export const spacing = {
+  xs: '4px',
+  sm: '8px',
+  md: '16px',
+  lg: '24px',
+  xl: '32px',
+};

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -2,13 +2,14 @@
 module.exports = {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
-    extend: {
-      colors: {
-        primary: { DEFAULT: '#002d2b' },
-        secondary: { 100: '#00fff4', 500: '#00968f' },
+    colors: {
+      brand: {
+        DEFAULT: '#002d2b',
+        secondary: '#00968f',
+        accent: '#00fff4',
       },
     },
+    extend: {},
   },
   plugins: [],
 };
-


### PR DESCRIPTION
## Summary
- add design tokens with colors, typography, and spacing
- implement `ClimaTrakThemeProvider`
- expose tokens via `useTokens` hook
- configure Tailwind with brand colors
- wrap app with theme provider
- add Storybook stories and initial testing setup

## Testing
- `pnpm --filter frontend format`
- `pnpm --filter frontend lint` *(fails: ESLint couldn't find a config)*
- `pnpm --filter frontend test` *(fails: jest: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68561f97098c832cad0d40e7e73bbdae