### PR TITLE
feat: implement AppShell layout and navigation

### DIFF
--- a/frontend/cypress/e2e/topnav.cy.ts
+++ b/frontend/cypress/e2e/topnav.cy.ts
@@ -1,0 +1,9 @@
+describe('top navigation drawer', () => {
+  it('opens drawer and navigates', () => {
+    cy.visit('/');
+    cy.viewport(400, 800);
+    cy.get('[aria-label="Toggle navigation"]').click();
+    cy.contains('Ativos').click();
+    cy.url().should('include', '/app/assets');
+  });
+});

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import ClimaTrakThemeProvider from './providers/ClimaTrakThemeProvider';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <ClimaTrakThemeProvider>
-      <App />
-    </ClimaTrakThemeProvider>
+    <BrowserRouter>
+      <ClimaTrakThemeProvider>
+        <App />
+      </ClimaTrakThemeProvider>
+    </BrowserRouter>
   </React.StrictMode>,
 );

--- a/frontend/src/presentation/App.tsx
+++ b/frontend/src/presentation/App.tsx
@@ -1,4 +1,24 @@
-const App = () => <h1>Hello ClimaTrak</h1>;
+import { Navigate, Route, Routes } from 'react-router-dom';
+import AppLayout from './components/layout/AppLayout';
+import Overview from './pages/Overview';
+import Assets from './pages/Assets';
+import WorkOrders from './pages/WorkOrders';
+import Plans from './pages/Plans';
+import Metrics from './pages/Metrics';
+import Reports from './pages/Reports';
+
+const App = () => (
+  <Routes>
+    <Route path="/" element={<Navigate to="/app/overview" replace />} />
+    <Route path="/app" element={<AppLayout />}> 
+      <Route path="overview" element={<Overview />} />
+      <Route path="assets" element={<Assets />} />
+      <Route path="work-orders" element={<WorkOrders />} />
+      <Route path="plans" element={<Plans />} />
+      <Route path="metrics" element={<Metrics />} />
+      <Route path="reports" element={<Reports />} />
+    </Route>
+  </Routes>
+);
 
 export default App;
-

--- a/frontend/src/presentation/components/layout/AppLayout.tsx
+++ b/frontend/src/presentation/components/layout/AppLayout.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+import { AppShell } from '@mantine/core';
+import { Outlet } from 'react-router-dom';
+import TopNav from './TopNav';
+
+interface Props {
+  children?: ReactNode;
+}
+
+const AppLayout = ({ children }: Props) => (
+  <AppShell header={{ height: 64 }} padding="md">
+    <AppShell.Header>
+      <TopNav />
+    </AppShell.Header>
+    <AppShell.Main>{children || <Outlet />}</AppShell.Main>
+  </AppShell>
+);
+
+export default AppLayout;

--- a/frontend/src/presentation/components/layout/TopNav.tsx
+++ b/frontend/src/presentation/components/layout/TopNav.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+import { NavLink } from 'react-router-dom';
+import {
+  Header,
+  Group,
+  Burger,
+  Drawer,
+  Stack,
+  ActionIcon,
+  Badge,
+  Avatar,
+  Menu,
+  Button,
+  useMantineTheme,
+} from '@mantine/core';
+import { useDisclosure, useMediaQuery } from '@mantine/hooks';
+
+const links = [
+  { label: 'Visão Geral', to: '/app/overview' },
+  { label: 'Ativos', to: '/app/assets' },
+  { label: 'Ordens de Serviço', to: '/app/work-orders' },
+  { label: 'Planos', to: '/app/plans' },
+  { label: 'Métricas', to: '/app/metrics' },
+  { label: 'Relatórios', to: '/app/reports' },
+];
+
+const TopNav = () => {
+  const theme = useMantineTheme();
+  const [opened, { toggle, close }] = useDisclosure(false);
+  const isMobile = useMediaQuery(`(max-width: ${theme.breakpoints.md})`);
+  const [module, setModule] = useState('TrakNor');
+
+  const items = links.map((link) => (
+    <Button
+      key={link.to}
+      component={NavLink}
+      to={link.to}
+      variant="subtle"
+      color="gray"
+      onClick={() => isMobile && close()}
+      className={({ isActive }) =>
+        `${isActive ? 'text-[#00968f]' : 'text-gray-200'} hover:opacity-80`}
+    >
+      {link.label}
+    </Button>
+  ));
+
+  return (
+    <Header height={64} className="bg-[#002d2b] text-gray-200">
+      <Group justify="space-between" h="100%" px="md">
+        <Group gap="sm">
+          {isMobile && (
+            <Burger
+              opened={opened}
+              onClick={toggle}
+              aria-label="Toggle navigation"
+              color="white"
+            />
+          )}
+          <span className="font-bold">ClimaTrak</span>
+          <Menu withinPortal>
+            <Menu.Target>
+              <Button variant="subtle" color="gray">
+                {module}
+              </Button>
+            </Menu.Target>
+            <Menu.Dropdown>
+              <Menu.Item onClick={() => setModule('TrakNor')}>TrakNor</Menu.Item>
+              <Menu.Item onClick={() => setModule('TrakSense')}>TrakSense</Menu.Item>
+            </Menu.Dropdown>
+          </Menu>
+        </Group>
+        {!isMobile && <Group gap="sm">{items}</Group>}
+        <Group gap="sm">
+          <ActionIcon variant="subtle" color="gray">
+            <Badge color="red" variant="filled" size="xs">
+              3
+            </Badge>
+          </ActionIcon>
+          <Avatar radius="xl" size="sm" color="cyan">
+            U
+          </Avatar>
+        </Group>
+      </Group>
+      <Drawer opened={opened} onClose={close} padding="md" size="xs">
+        <Stack>{items}</Stack>
+      </Drawer>
+    </Header>
+  );
+};
+
+export default TopNav;

--- a/frontend/src/presentation/components/layout/__tests__/TopNav.test.tsx
+++ b/frontend/src/presentation/components/layout/__tests__/TopNav.test.tsx
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import TopNav from '../TopNav';
+
+test('renders navigation links', () => {
+  const { container, getByText } = render(
+    <MemoryRouter>
+      <TopNav />
+    </MemoryRouter>,
+  );
+  expect(getByText('Visão Geral')).toBeInTheDocument();
+  expect(container).toMatchSnapshot();
+});

--- a/frontend/src/presentation/pages/Assets.tsx
+++ b/frontend/src/presentation/pages/Assets.tsx
@@ -1,0 +1,2 @@
+const Assets = () => <h1>Ativos</h1>;
+export default Assets;

--- a/frontend/src/presentation/pages/Metrics.tsx
+++ b/frontend/src/presentation/pages/Metrics.tsx
@@ -1,0 +1,2 @@
+const Metrics = () => <h1>Métricas</h1>;
+export default Metrics;

--- a/frontend/src/presentation/pages/Overview.tsx
+++ b/frontend/src/presentation/pages/Overview.tsx
@@ -1,0 +1,2 @@
+const Overview = () => <h1>Visão Geral</h1>;
+export default Overview;

--- a/frontend/src/presentation/pages/Plans.tsx
+++ b/frontend/src/presentation/pages/Plans.tsx
@@ -1,0 +1,2 @@
+const Plans = () => <h1>Planos</h1>;
+export default Plans;

--- a/frontend/src/presentation/pages/Reports.tsx
+++ b/frontend/src/presentation/pages/Reports.tsx
@@ -1,0 +1,2 @@
+const Reports = () => <h1>Relatórios</h1>;
+export default Reports;

--- a/frontend/src/presentation/pages/WorkOrders.tsx
+++ b/frontend/src/presentation/pages/WorkOrders.tsx
@@ -1,0 +1,2 @@
+const WorkOrders = () => <h1>Ordens de Serviço</h1>;
+export default WorkOrders;


### PR DESCRIPTION
## Summary
- create `TopNav` component with module selector, links and icons
- create `AppLayout` using Mantine `AppShell`
- add placeholder pages for app sections
- update routing in `App.tsx` and `main.tsx`
- add Jest snapshot and Cypress E2E tests

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*
- `ruff .` *(fails: unrecognized subcommand)*
- `pnpm lint` *(fails: node_modules missing)*
- `pnpm test` *(fails: jest not found)*
- `pnpm dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68562092a348832cb833021919dc2d19