### PR TITLE
Implement routing authentication guard

### DIFF
--- a/frontend/cypress/e2e/auth.cy.ts
+++ b/frontend/cypress/e2e/auth.cy.ts
@@ -1,0 +1,6 @@
+describe('auth guard', () => {
+  it('redirects to login when accessing /app without token', () => {
+    cy.visit('/app');
+    cy.url().should('include', '/login');
+  });
+});

--- a/frontend/src/application/hooks/useIsAuthenticated.ts
+++ b/frontend/src/application/hooks/useIsAuthenticated.ts
@@ -1,0 +1,5 @@
+import { useAuthStore } from '../stores/authStore';
+
+const useIsAuthenticated = () => !!useAuthStore((state) => state.token);
+
+export default useIsAuthenticated;

--- a/frontend/src/application/stores/authStore.ts
+++ b/frontend/src/application/stores/authStore.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { AuthState } from '../../domain/auth';
+
+interface AuthActions {
+  login: (token: string) => void;
+  logout: () => void;
+}
+
+export type AuthStore = AuthState & AuthActions;
+
+export const useAuthStore = create<AuthStore>()(
+  persist(
+    (set) => ({
+      token: null,
+      login: (token: string) => set({ token }),
+      logout: () => set({ token: null }),
+    }),
+    {
+      name: 'auth',
+    },
+  ),
+);

--- a/frontend/src/components/routes/AuthGuard.tsx
+++ b/frontend/src/components/routes/AuthGuard.tsx
@@ -1,0 +1,19 @@
+import { Navigate } from 'react-router-dom';
+import { ReactNode } from 'react';
+import useIsAuthenticated from '../../application/hooks/useIsAuthenticated';
+
+interface Props {
+  children: ReactNode;
+}
+
+const AuthGuard = ({ children }: Props) => {
+  const authenticated = useIsAuthenticated();
+
+  if (!authenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default AuthGuard;

--- a/frontend/src/components/routes/ProtectedRoute.tsx
+++ b/frontend/src/components/routes/ProtectedRoute.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from 'react';
+import AuthGuard from './AuthGuard';
+
+interface Props {
+  children: ReactNode;
+}
+
+const ProtectedRoute = ({ children }: Props) => (
+  <AuthGuard>{children}</AuthGuard>
+);
+
+export default ProtectedRoute;

--- a/frontend/src/components/routes/__tests__/ProtectedRoute.test.tsx
+++ b/frontend/src/components/routes/__tests__/ProtectedRoute.test.tsx
@@ -1,0 +1,32 @@
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { render } from '@testing-library/react';
+import ProtectedRoute from '../ProtectedRoute';
+import { useAuthStore } from '../../../application/stores/authStore';
+
+describe('ProtectedRoute', () => {
+  it('redirects to login when unauthenticated', () => {
+    useAuthStore.setState({ token: null });
+    const { container } = render(
+      <MemoryRouter initialEntries={["/app"]}>
+        <Routes>
+          <Route path="/login" element={<div>Login</div>} />
+          <Route path="/app" element={<ProtectedRoute><div>App</div></ProtectedRoute>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(container.innerHTML).toContain('Login');
+  });
+
+  it('renders children when authenticated', () => {
+    useAuthStore.setState({ token: 'token' });
+    const { getByText } = render(
+      <MemoryRouter initialEntries={["/app"]}>
+        <Routes>
+          <Route path="/login" element={<div>Login</div>} />
+          <Route path="/app" element={<ProtectedRoute><div>App</div></ProtectedRoute>} />
+        </Routes>
+      </MemoryRouter>
+    );
+    expect(getByText('App')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/domain/auth.ts
+++ b/frontend/src/domain/auth.ts
@@ -1,0 +1,3 @@
+export interface AuthState {
+  token: string | null;
+}

--- a/frontend/src/presentation/App.tsx
+++ b/frontend/src/presentation/App.tsx
@@ -1,24 +1,5 @@
-import { Navigate, Route, Routes } from 'react-router-dom';
-import AppLayout from './components/layout/AppLayout';
-import Overview from './pages/Overview';
-import Assets from './pages/Assets';
-import WorkOrders from './pages/WorkOrders';
-import Plans from './pages/Plans';
-import Metrics from './pages/Metrics';
-import Reports from './pages/Reports';
+import Router from '../routes';
 
-const App = () => (
-  <Routes>
-    <Route path="/" element={<Navigate to="/app/overview" replace />} />
-    <Route path="/app" element={<AppLayout />}> 
-      <Route path="overview" element={<Overview />} />
-      <Route path="assets" element={<Assets />} />
-      <Route path="work-orders" element={<WorkOrders />} />
-      <Route path="plans" element={<Plans />} />
-      <Route path="metrics" element={<Metrics />} />
-      <Route path="reports" element={<Reports />} />
-    </Route>
-  </Routes>
-);
+const App = () => <Router />;
 
 export default App;

--- a/frontend/src/presentation/pages/Login.tsx
+++ b/frontend/src/presentation/pages/Login.tsx
@@ -1,0 +1,22 @@
+import { Button } from '@mantine/core';
+import { useNavigate } from 'react-router-dom';
+import { useAuthStore } from '../../application/stores/authStore';
+
+const Login = () => {
+  const navigate = useNavigate();
+  const login = useAuthStore((state) => state.login);
+
+  const handleLogin = () => {
+    login('dummy');
+    navigate('/app/overview', { replace: true });
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="mb-4 text-xl">Login</h1>
+      <Button onClick={handleLogin}>Entrar</Button>
+    </div>
+  );
+};
+
+export default Login;

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,0 +1,41 @@
+import { Navigate, Route, Routes } from 'react-router-dom';
+import AppLayout from '../presentation/components/layout/AppLayout';
+import Overview from '../presentation/pages/Overview';
+import Assets from '../presentation/pages/Assets';
+import WorkOrders from '../presentation/pages/WorkOrders';
+import Plans from '../presentation/pages/Plans';
+import Metrics from '../presentation/pages/Metrics';
+import Reports from '../presentation/pages/Reports';
+import Login from '../presentation/pages/Login';
+import AuthGuard from '../components/routes/AuthGuard';
+import useIsAuthenticated from '../application/hooks/useIsAuthenticated';
+
+const Router = () => {
+  const isAuthenticated = useIsAuthenticated();
+  return (
+    <Routes>
+      <Route path="/login" element={<Login />} />
+      <Route
+        path="/app/*"
+        element={
+          <AuthGuard>
+            <AppLayout />
+          </AuthGuard>
+        }
+      >
+        <Route path="overview" element={<Overview />} />
+        <Route path="assets" element={<Assets />} />
+        <Route path="work-orders" element={<WorkOrders />} />
+        <Route path="plans" element={<Plans />} />
+        <Route path="metrics" element={<Metrics />} />
+        <Route path="reports" element={<Reports />} />
+      </Route>
+      <Route
+        path="*"
+        element={<Navigate to={isAuthenticated ? '/app/overview' : '/login'} replace />}
+      />
+    </Routes>
+  );
+};
+
+export default Router;


### PR DESCRIPTION
## Summary
- add auth state and store following Clean Architecture
- create AuthGuard and ProtectedRoute components
- implement application router with login and protected `/app` routes
- add simple login page
- cover authentication guard with unit and e2e tests

## Testing
- `pnpm lint` *(fails: ESLint config missing)*
- `pnpm test` *(fails: jest not found)*
- `pnpm dev` *(fails: vite not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6856218c4214832cab5e724af6756a10