### PR TITLE
FE06 Dashboard Skeleton

### DIFF
--- a/frontend/cypress/e2e/dashboard.cy.ts
+++ b/frontend/cypress/e2e/dashboard.cy.ts
@@ -1,0 +1,11 @@
+describe('dashboard page', () => {
+  it('renders metrics and charts', () => {
+    cy.visit('/login');
+    cy.get('input[name="email"]').type('test@example.com');
+    cy.get('input[name="password"]').type('password');
+    cy.contains('Entrar').click();
+    cy.url().should('include', '/app');
+    cy.contains('OS Abertas');
+    cy.contains('Status dos ativos');
+  });
+});

--- a/frontend/src/presentation/components/ChartCard.tsx
+++ b/frontend/src/presentation/components/ChartCard.tsx
@@ -1,0 +1,18 @@
+import { Card, Text } from '@mantine/core';
+import { ReactNode } from 'react';
+
+interface Props {
+  title: string;
+  children: ReactNode;
+}
+
+const ChartCard = ({ title, children }: Props) => (
+  <Card padding="md" radius="md" withBorder>
+    <Text mb="sm" fw={700}>
+      {title}
+    </Text>
+    {children}
+  </Card>
+);
+
+export default ChartCard;

--- a/frontend/src/presentation/components/StatCard.tsx
+++ b/frontend/src/presentation/components/StatCard.tsx
@@ -1,0 +1,23 @@
+import { Card, Text } from '@mantine/core';
+import { ReactNode } from 'react';
+
+interface Props {
+  label: string;
+  value: number | string;
+  statusColor?: string;
+  icon?: ReactNode;
+}
+
+const StatCard = ({ label, value, statusColor = 'blue', icon }: Props) => (
+  <Card padding="md" radius="md" withBorder>
+    <Text size="sm" c="dimmed">
+      {label}
+    </Text>
+    <Text size="xl" fw={700} c={statusColor}>
+      {value}
+    </Text>
+    {icon}
+  </Card>
+);
+
+export default StatCard;

--- a/frontend/src/presentation/pages/DashboardPage.tsx
+++ b/frontend/src/presentation/pages/DashboardPage.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { SimpleGrid, Skeleton, Stack, Title } from '@mantine/core';
+import StatCard from '../components/StatCard';
+import ChartCard from '../components/ChartCard';
+import DashboardService, { DashboardStats } from '../../services/DashboardService';
+
+const DashboardPage = () => {
+  const [stats, setStats] = useState<DashboardStats | null>(null);
+
+  useEffect(() => {
+    DashboardService.getStats().then(setStats);
+  }, []);
+
+  if (!stats) {
+    return (
+      <Stack p="lg">
+        <Title order={1}>Dashboard</Title>
+        <SimpleGrid cols={{ base: 2, sm: 3, md: 5 }} spacing="md">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} h={80} radius="md" />
+          ))}
+        </SimpleGrid>
+        <Skeleton h={300} radius="md" mt="md" />
+        <Skeleton h={300} radius="md" mt="md" />
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack p="lg">
+      <Title order={1}>Dashboard</Title>
+      <SimpleGrid cols={{ base: 2, sm: 3, md: 5 }} spacing="md">
+        {stats.kpis.map((kpi) => (
+          <StatCard key={kpi.label} {...kpi} />
+        ))}
+      </SimpleGrid>
+      <SimpleGrid cols={{ base: 1, md: 2 }} spacing="md" mt="md">
+        <ChartCard title="Evolução das OS">
+          <div style={{ height: 240 }}>Gráfico Linha</div>
+        </ChartCard>
+        <ChartCard title="Status dos ativos">
+          <div style={{ height: 240 }}>Gráfico Pizza</div>
+        </ChartCard>
+      </SimpleGrid>
+    </Stack>
+  );
+};
+
+export default DashboardPage;

--- a/frontend/src/presentation/pages/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/presentation/pages/__tests__/DashboardPage.test.tsx
@@ -1,0 +1,28 @@
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import DashboardPage from '../DashboardPage';
+import ClimaTrakThemeProvider from '../../../providers/ClimaTrakThemeProvider';
+import DashboardService from '../../../services/DashboardService';
+
+jest.mock('../../../services/DashboardService');
+
+const mockedStats = {
+  kpis: [{ label: 'OS Abertas', value: 1, statusColor: 'blue' }],
+  ordersEvolution: [],
+  assetStatus: [],
+};
+
+(DashboardService.getStats as jest.Mock).mockResolvedValue(mockedStats);
+
+test('dashboard renders KPIs and charts', async () => {
+  const { container, findByText } = render(
+    <MemoryRouter>
+      <ClimaTrakThemeProvider>
+        <DashboardPage />
+      </ClimaTrakThemeProvider>
+    </MemoryRouter>
+  );
+
+  expect(await findByText('OS Abertas')).toBeInTheDocument();
+  expect(container).toMatchSnapshot();
+});

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -6,6 +6,7 @@ import WorkOrders from '../presentation/pages/WorkOrders';
 import Plans from '../presentation/pages/Plans';
 import Metrics from '../presentation/pages/Metrics';
 import Reports from '../presentation/pages/Reports';
+import DashboardPage from '../presentation/pages/DashboardPage';
 import LoginPage from '../presentation/pages/LoginPage';
 import AuthGuard from '../components/routes/AuthGuard';
 import useIsAuthenticated from '../application/hooks/useIsAuthenticated';
@@ -23,6 +24,7 @@ const Router = () => {
           </AuthGuard>
         }
       >
+        <Route index element={<DashboardPage />} />
         <Route path="overview" element={<Overview />} />
         <Route path="assets" element={<Assets />} />
         <Route path="work-orders" element={<WorkOrders />} />

--- a/frontend/src/services/DashboardService.ts
+++ b/frontend/src/services/DashboardService.ts
@@ -1,0 +1,49 @@
+export interface Kpi {
+  label: string;
+  value: number | string;
+  statusColor: string;
+}
+
+export interface OrdersEvolutionPoint {
+  date: string;
+  value: number;
+}
+
+export interface AssetStatusData {
+  name: string;
+  value: number;
+}
+
+export interface DashboardStats {
+  kpis: Kpi[];
+  ordersEvolution: OrdersEvolutionPoint[];
+  assetStatus: AssetStatusData[];
+}
+
+const DashboardService = {
+  async getStats(): Promise<DashboardStats> {
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    return {
+      kpis: [
+        { label: 'OS Abertas', value: 8, statusColor: 'blue' },
+        { label: 'OS Atrasadas', value: 2, statusColor: 'orange' },
+        { label: 'OS Críticas', value: 1, statusColor: 'red' },
+        { label: 'MTTR', value: '5h', statusColor: 'blue' },
+        { label: 'MTBF', value: '100h', statusColor: 'blue' },
+      ],
+      ordersEvolution: [
+        { date: 'Jan', value: 3 },
+        { date: 'Fev', value: 4 },
+        { date: 'Mar', value: 2 },
+        { date: 'Abr', value: 5 },
+      ],
+      assetStatus: [
+        { name: 'Operacional', value: 10 },
+        { name: 'Manutenção', value: 2 },
+        { name: 'Parado', value: 1 },
+      ],
+    };
+  },
+};
+
+export default DashboardService;


### PR DESCRIPTION
## Summary
- implement dashboard skeleton page and service
- create reusable StatCard and ChartCard components
- add dashboard route and tests
- add dashboard E2E test

## Testing
- `pnpm lint` *(fails: node_modules missing)*
- `pnpm test` *(fails: jest not found)*
- `pnpm dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685625ee7e18832cb24cb9596837bc82