### PR TITLE
FE07 Add StatCard & ChartCard components

### DIFF
--- a/frontend/src/presentation/components/ChartCard.stories.tsx
+++ b/frontend/src/presentation/components/ChartCard.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from '@mantine/core';
+import ChartCard from './ChartCard';
+
+const meta: Meta<typeof ChartCard> = {
+  title: 'Components/ChartCard',
+  component: ChartCard,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ChartCard>;
+
+export const Default: Story = {
+  render: () => (
+    <ChartCard title="Exemplo de Gráfico">
+      <div
+        style={{
+          height: 240,
+          background: '#eee',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        Gráfico aqui
+      </div>
+    </ChartCard>
+  ),
+};
+
+export const WithActions: Story = {
+  render: () => (
+    <ChartCard title="Com Ações" actions={<Button size="xs">Exportar</Button>}>
+      <div
+        style={{
+          height: 240,
+          background: '#eee',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+        }}
+      >
+        Gráfico aqui
+      </div>
+    </ChartCard>
+  ),
+};

--- a/frontend/src/presentation/components/ChartCard.test.tsx
+++ b/frontend/src/presentation/components/ChartCard.test.tsx
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react';
+import ChartCard from './ChartCard';
+import ClimaTrakThemeProvider from '../../providers/ClimaTrakThemeProvider';
+
+test('chart card renders correctly', () => {
+  const { container, getByText } = render(
+    <ClimaTrakThemeProvider>
+      <ChartCard title="Chart">
+        <div>Content</div>
+      </ChartCard>
+    </ClimaTrakThemeProvider>,
+  );
+
+  expect(getByText('Chart')).toBeInTheDocument();
+  expect(container).toMatchSnapshot();
+});

--- a/frontend/src/presentation/components/ChartCard.tsx
+++ b/frontend/src/presentation/components/ChartCard.tsx
@@ -1,18 +1,32 @@
-import { Card, Text } from '@mantine/core';
+import { Divider, Group, Paper, Text } from '@mantine/core';
 import { ReactNode } from 'react';
+import useTokens from '../../hooks/useTokens';
 
 interface Props {
   title: string;
   children: ReactNode;
+  actions?: ReactNode;
+  minHeight?: number | string;
 }
 
-const ChartCard = ({ title, children }: Props) => (
-  <Card padding="md" radius="md" withBorder>
-    <Text mb="sm" fw={700}>
-      {title}
-    </Text>
-    {children}
-  </Card>
-);
+const ChartCard = ({ title, children, actions, minHeight = 240 }: Props) => {
+  const { spacing } = useTokens();
+  return (
+    <Paper
+      withBorder
+      shadow="sm"
+      radius="xl"
+      p="md"
+      style={{ width: '100%', minHeight }}
+    >
+      <Group justify="space-between" mb="sm">
+        <Text fw={700}>{title}</Text>
+        {actions}
+      </Group>
+      <Divider mb={spacing.sm} />
+      {children}
+    </Paper>
+  );
+};
 
 export default ChartCard;

--- a/frontend/src/presentation/components/StatCard.stories.tsx
+++ b/frontend/src/presentation/components/StatCard.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import StatCard from './StatCard';
+import { Button } from '@mantine/core';
+
+const meta: Meta<typeof StatCard> = {
+  title: 'Components/StatCard',
+  component: StatCard,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof StatCard>;
+
+export const Default: Story = {
+  render: () => (
+    <StatCard
+      label="OS Abertas"
+      value={8}
+      statusColor="green"
+      icon={
+        <span role="img" aria-label="up">
+          📈
+        </span>
+      }
+    />
+  ),
+};
+
+export const Warning: Story = {
+  render: () => (
+    <StatCard
+      label="OS Atrasadas"
+      value={2}
+      statusColor="orange"
+      icon={
+        <span role="img" aria-label="warning">
+          ⚠️
+        </span>
+      }
+    />
+  ),
+};

--- a/frontend/src/presentation/components/StatCard.test.tsx
+++ b/frontend/src/presentation/components/StatCard.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@testing-library/react';
+import StatCard from './StatCard';
+import ClimaTrakThemeProvider from '../../providers/ClimaTrakThemeProvider';
+
+test('stat card renders correctly', () => {
+  const { container, getByText } = render(
+    <ClimaTrakThemeProvider>
+      <StatCard label="OS" value={1} statusColor="blue" />
+    </ClimaTrakThemeProvider>,
+  );
+
+  expect(getByText('OS')).toBeInTheDocument();
+  expect(container).toMatchSnapshot();
+});

--- a/frontend/src/presentation/components/StatCard.tsx
+++ b/frontend/src/presentation/components/StatCard.tsx
@@ -1,23 +1,35 @@
-import { Card, Text } from '@mantine/core';
+import { Card, Group, Stack, Text } from '@mantine/core';
 import { ReactNode } from 'react';
+import useTokens from '../../hooks/useTokens';
 
 interface Props {
-  label: string;
-  value: number | string;
-  statusColor?: string;
   icon?: ReactNode;
+  label: string;
+  value: string | number;
+  statusColor: string;
 }
 
-const StatCard = ({ label, value, statusColor = 'blue', icon }: Props) => (
-  <Card padding="md" radius="md" withBorder>
-    <Text size="sm" c="dimmed">
-      {label}
-    </Text>
-    <Text size="xl" fw={700} c={statusColor}>
-      {value}
-    </Text>
-    {icon}
-  </Card>
-);
+const StatCard = ({ icon, label, value, statusColor }: Props) => {
+  const { typography } = useTokens();
+
+  return (
+    <Card withBorder shadow="sm" radius="xl" p="lg">
+      <Group align="center">
+        {icon && <div>{icon}</div>}
+        <Stack gap={0}>
+          <Text c="dimmed" style={{ fontSize: typography.caption14 }}>
+            {label}
+          </Text>
+          <Text
+            fw={700}
+            style={{ fontSize: typography.heading48, color: statusColor }}
+          >
+            {value}
+          </Text>
+        </Stack>
+      </Group>
+    </Card>
+  );
+};
 
 export default StatCard;

--- a/frontend/src/styles/tokens.ts
+++ b/frontend/src/styles/tokens.ts
@@ -15,6 +15,7 @@ export const typography = {
   heading32: '32px',
   heading24: '24px',
   body16: '16px',
+  caption14: '14px',
   caption12: '12px',
 };
 


### PR DESCRIPTION
## Summary
- style tokens: add caption14
- implement StatCard using tokens and icon support
- implement ChartCard with actions slot and minHeight prop
- document components in Storybook
- add snapshot tests for StatCard and ChartCard

## Testing
- `pnpm lint` *(fails: ESLint couldn't find config)*
- `pnpm test` *(fails: jest not found)*
- `pnpm storybook` *(fails: storybook not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685626eaf554832c88f7e0bef9b07fc9