### PR TITLE
feat(storybook): design tokens and interactive stories

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -4,6 +4,7 @@ const config: StorybookConfig = {
   stories: ['../src/**/*.stories.tsx'],
   addons: ['@storybook/addon-essentials'],
   framework: '@storybook/react-vite',
+  docs: { autodocs: true },
 };
 
 export default config;

--- a/frontend/.storybook/preview.tsx
+++ b/frontend/.storybook/preview.tsx
@@ -3,6 +3,15 @@ import React from 'react';
 import ClimaTrakThemeProvider from '../src/providers/ClimaTrakThemeProvider';
 
 const preview: Preview = {
+  parameters: {
+    backgrounds: {
+      default: 'dark',
+      values: [
+        { name: 'light', value: '#ffffff' },
+        { name: 'dark', value: '#000000' },
+      ],
+    },
+  },
   decorators: [
     (Story) => (
       <ClimaTrakThemeProvider>
@@ -13,3 +22,4 @@ const preview: Preview = {
 };
 
 export default preview;
+

--- a/frontend/src/DesignTokens.stories.tsx
+++ b/frontend/src/DesignTokens.stories.tsx
@@ -30,3 +30,33 @@ export const Colors = () => {
     </div>
   );
 };
+
+export const Typography = () => {
+  const { typography } = useTokens();
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {Object.entries(typography).map(([token, size]) => (
+        <div key={token} style={{ fontSize: size }}>
+          {token}: {size}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export const Spacing = () => {
+  const { spacing } = useTokens();
+  return (
+    <div style={{ display: 'flex', gap: 16 }}>
+      {Object.entries(spacing).map(([token, space]) => (
+        <div
+          key={token}
+          style={{ width: space, height: space, background: '#eee', position: 'relative' }}
+        >
+          <span style={{ position: 'absolute', top: '100%' }}>{token}</span>
+        </div>
+      ))}
+    </div>
+  );
+};
+

--- a/frontend/src/presentation/components/Button.stories.tsx
+++ b/frontend/src/presentation/components/Button.stories.tsx
@@ -1,22 +1,34 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { useMantineColorScheme, Button } from '@mantine/core';
+import type { ButtonProps } from '@mantine/core';
+import { useMantineColorScheme } from '@mantine/core';
+import Button from './Button';
 
-const meta: Meta = {
+const meta: Meta<typeof Button> = {
   title: 'Components/Button',
   component: Button,
+  argTypes: {
+    color: { control: 'color' },
+    size: {
+      control: { type: 'select' },
+      options: ['xs', 'sm', 'md', 'lg', 'xl'],
+    },
+    leftSection: { control: 'text' },
+  },
 };
 
 export default meta;
 
-type Story = StoryObj<typeof Button>;
+type Story = StoryObj<ButtonProps>;
 
-export const Default: Story = {
-  render: () => {
+export const Playground: Story = {
+  args: { children: 'Button', color: 'brand', size: 'md' },
+  render: (args) => {
     const { colorScheme, toggleColorScheme } = useMantineColorScheme();
     return (
-      <div>
-        <Button onClick={() => toggleColorScheme()}>{colorScheme} mode</Button>
-      </div>
+      <Button {...args} onClick={() => toggleColorScheme()}>
+        {args.children} - {colorScheme} mode
+      </Button>
     );
   },
 };
+

--- a/frontend/src/presentation/components/ChartCard.stories.tsx
+++ b/frontend/src/presentation/components/ChartCard.stories.tsx
@@ -5,15 +5,34 @@ import ChartCard from './ChartCard';
 const meta: Meta<typeof ChartCard> = {
   title: 'Components/ChartCard',
   component: ChartCard,
+  argTypes: {
+    title: { control: 'text' },
+    minHeight: { control: 'number' },
+    showActions: { control: 'boolean' },
+  },
 };
 
 export default meta;
 
-type Story = StoryObj<typeof ChartCard>;
+interface Args {
+  title: string;
+  minHeight?: number;
+  showActions?: boolean;
+}
+type Story = StoryObj<Args>;
 
-export const Default: Story = {
-  render: () => (
-    <ChartCard title="Exemplo de Gráfico">
+export const Playground: Story = {
+  args: {
+    title: 'Exemplo de Gráfico',
+    minHeight: 240,
+    showActions: false,
+  },
+  render: ({ title, minHeight, showActions }) => (
+    <ChartCard
+      title={title}
+      minHeight={minHeight}
+      actions={showActions ? <Button size="xs">Exportar</Button> : undefined}
+    >
       <div
         style={{
           height: 240,
@@ -29,20 +48,3 @@ export const Default: Story = {
   ),
 };
 
-export const WithActions: Story = {
-  render: () => (
-    <ChartCard title="Com Ações" actions={<Button size="xs">Exportar</Button>}>
-      <div
-        style={{
-          height: 240,
-          background: '#eee',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        Gráfico aqui
-      </div>
-    </ChartCard>
-  ),
-};

--- a/frontend/src/presentation/components/StatCard.stories.tsx
+++ b/frontend/src/presentation/components/StatCard.stories.tsx
@@ -1,42 +1,45 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import StatCard from './StatCard';
-import { Button } from '@mantine/core';
 
 const meta: Meta<typeof StatCard> = {
   title: 'Components/StatCard',
   component: StatCard,
+  argTypes: {
+    label: { control: 'text' },
+    value: { control: 'number' },
+    statusColor: { control: 'color' },
+    icon: { control: 'text' },
+  },
 };
 
 export default meta;
 
-type Story = StoryObj<typeof StatCard>;
+interface Args {
+  label: string;
+  value: number;
+  statusColor: string;
+  icon?: string;
+}
+type Story = StoryObj<Args>;
 
-export const Default: Story = {
-  render: () => (
+export const Playground: Story = {
+  args: {
+    label: 'OS Abertas',
+    value: 8,
+    statusColor: 'green',
+    icon: '📈',
+  },
+  render: ({ label, value, statusColor, icon }) => (
     <StatCard
-      label="OS Abertas"
-      value={8}
-      statusColor="green"
-      icon={
-        <span role="img" aria-label="up">
-          📈
+      label={label}
+      value={value}
+      statusColor={statusColor}
+      icon={icon ? (
+        <span role="img" aria-label="icon">
+          {icon}
         </span>
-      }
+      ) : undefined}
     />
   ),
 };
 
-export const Warning: Story = {
-  render: () => (
-    <StatCard
-      label="OS Atrasadas"
-      value={2}
-      statusColor="orange"
-      icon={
-        <span role="img" aria-label="warning">
-          ⚠️
-        </span>
-      }
-    />
-  ),
-};


### PR DESCRIPTION
## Summary
- add autodocs option to Storybook config and dark preview backgrounds
- showcase design tokens for colors, typography and spacing
- improve Button story with interactive controls
- improve ChartCard story with title, height and action toggles
- improve StatCard story with configurable props

## Testing
- `pnpm lint` *(fails: ESLint couldn't find configuration and node_modules)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685627e834a0832c9465d3904b30f65f