### PR TITLE
Fix ESLint config

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -4,7 +4,11 @@ module.exports = {
     es2021: true,
     node: true,
   },
-  extends: ['airbnb-typescript', 'airbnb/hooks', 'prettier'],
+  extends: [
+    'airbnb-typescript',
+    'plugin:react-hooks/recommended',
+    'prettier',
+  ],
   parserOptions: {
     project: './tsconfig.json',
   },


### PR DESCRIPTION
## Summary
- update ESLint configuration to drop missing `airbnb/hooks` preset
- enable recommended React hooks rules

## Testing
- `pytest`
- `pnpm lint` *(fails: Local package.json exists, but node_modules missing)*

------
https://chatgpt.com/codex/tasks/task_e_68562b3f9cc0832cb9bbc0260bca58db