### PR TITLE
Fix ESLint config setup

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-config-prettier": "^9.1.0",
     "postcss": "^8.4.31",
     "prettier": "^3.1.0",
     "tailwindcss": "^3.4.0",


### PR DESCRIPTION
## Summary
- add `eslint-config-prettier` to dev dependencies

## Testing
- `pytest -q`
- `pnpm -r lint` *(fails: ESLint couldn't find config due to missing node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_68562c2951f4832caab469fd12075862