### PR TITLE
Implement equipamentos page

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,16 +1,21 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
 import ClimaTrakThemeProvider from './providers/ClimaTrakThemeProvider';
 import './index.css';
 
+const queryClient = new QueryClient();
+
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <BrowserRouter>
-      <ClimaTrakThemeProvider>
-        <App />
-      </ClimaTrakThemeProvider>
+      <QueryClientProvider client={queryClient}>
+        <ClimaTrakThemeProvider>
+          <App />
+        </ClimaTrakThemeProvider>
+      </QueryClientProvider>
     </BrowserRouter>
   </React.StrictMode>,
 );

--- a/frontend/src/modules/assets/application/useEquipments.ts
+++ b/frontend/src/modules/assets/application/useEquipments.ts
@@ -1,0 +1,29 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import EquipmentService from '../infrastructure/EquipmentService';
+import { EquipmentInput } from '../domain/equipment';
+
+export const useEquipments = () => {
+  const queryClient = useQueryClient();
+  const listQuery = useQuery({
+    queryKey: ['equipments'],
+    queryFn: () => EquipmentService.list(),
+  });
+
+  const create = useMutation({
+    mutationFn: (data: EquipmentInput) => EquipmentService.create(data),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['equipments'] }),
+  });
+
+  const update = useMutation({
+    mutationFn: ({ id, data }: { id: number; data: EquipmentInput }) =>
+      EquipmentService.update(id, data),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['equipments'] }),
+  });
+
+  const remove = useMutation({
+    mutationFn: (id: number) => EquipmentService.remove(id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['equipments'] }),
+  });
+
+  return { ...listQuery, create, update, remove };
+};

--- a/frontend/src/modules/assets/domain/equipment.ts
+++ b/frontend/src/modules/assets/domain/equipment.ts
@@ -1,0 +1,10 @@
+export interface Equipment {
+  id: number;
+  name: string;
+  model: string;
+  tag: string;
+  location: string;
+  btus: number;
+}
+
+export type EquipmentInput = Omit<Equipment, 'id'>;

--- a/frontend/src/modules/assets/infrastructure/EquipmentService.ts
+++ b/frontend/src/modules/assets/infrastructure/EquipmentService.ts
@@ -1,0 +1,48 @@
+import { Equipment, EquipmentInput } from '../domain/equipment';
+
+let equipments: Equipment[] = [
+  { id: 1, name: 'Split 9000', model: 'LG', tag: 'HVAC-01', location: 'Sala 1', btus: 9000 },
+  { id: 2, name: 'Split 12000', model: 'Samsung', tag: 'HVAC-02', location: 'Sala 2', btus: 12000 },
+];
+
+const delay = () => new Promise((r) => setTimeout(r, 100));
+
+const EquipmentService = {
+  async list(): Promise<Equipment[]> {
+    await delay();
+    return equipments;
+  },
+  async create(data: EquipmentInput): Promise<Equipment> {
+    await delay();
+    const exists = equipments.some((e) => e.tag === data.tag);
+    if (exists) {
+      const err = new Error('TAG duplicada');
+      // @ts-ignore
+      err.status = 422;
+      throw err;
+    }
+    const newEquipment: Equipment = { id: Date.now(), ...data };
+    equipments.push(newEquipment);
+    return newEquipment;
+  },
+  async update(id: number, data: EquipmentInput): Promise<Equipment> {
+    await delay();
+    const idx = equipments.findIndex((e) => e.id === id);
+    if (idx === -1) throw new Error('Not found');
+    const exists = equipments.some((e) => e.tag === data.tag && e.id !== id);
+    if (exists) {
+      const err = new Error('TAG duplicada');
+      // @ts-ignore
+      err.status = 422;
+      throw err;
+    }
+    equipments[idx] = { id, ...data };
+    return equipments[idx];
+  },
+  async remove(id: number): Promise<void> {
+    await delay();
+    equipments = equipments.filter((e) => e.id !== id);
+  },
+};
+
+export default EquipmentService;

--- a/frontend/src/modules/assets/presentation/EquipamentoForm.tsx
+++ b/frontend/src/modules/assets/presentation/EquipamentoForm.tsx
@@ -1,0 +1,47 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Button, Group, NumberInput, TextInput } from '@mantine/core';
+import { useForm } from 'react-hook-form';
+import { EquipmentFormData, equipmentSchema } from '../schemas/equipmentSchema';
+
+interface Props {
+  initialValues?: EquipmentFormData;
+  onSubmit: (data: EquipmentFormData) => void;
+  onCancel: () => void;
+}
+
+const EquipamentoForm = ({ initialValues, onSubmit, onCancel }: Props) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<EquipmentFormData>({
+    resolver: zodResolver(equipmentSchema),
+    defaultValues: initialValues,
+  });
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+      <TextInput label="Nome" {...register('name')} error={errors.name?.message} />
+      <TextInput label="Modelo" {...register('model')} error={errors.model?.message} />
+      <TextInput label="TAG" {...register('tag')} error={errors.tag?.message} />
+      <TextInput
+        label="Localização"
+        {...register('location')}
+        error={errors.location?.message}
+      />
+      <NumberInput
+        label="BTUs"
+        {...register('btus', { valueAsNumber: true })}
+        error={errors.btus?.message}
+      />
+      <Group justify="flex-end" mt="md">
+        <Button variant="outline" onClick={onCancel} type="button">
+          Cancelar
+        </Button>
+        <Button type="submit">Salvar</Button>
+      </Group>
+    </form>
+  );
+};
+
+export default EquipamentoForm;

--- a/frontend/src/modules/assets/presentation/EquipamentosPage.tsx
+++ b/frontend/src/modules/assets/presentation/EquipamentosPage.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import {
+  Button,
+  Group,
+  Modal,
+  Stack,
+  Table,
+  Text,
+  Title,
+} from '@mantine/core';
+import { useEquipments } from '../application/useEquipments';
+import EquipamentoForm from './EquipamentoForm';
+import { EquipmentFormData } from '../schemas/equipmentSchema';
+
+const EquipamentosPage = () => {
+  const { data, isLoading, create, update, remove } = useEquipments();
+  const [opened, setOpened] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+
+  const editingItem = data?.find((e) => e.id === editingId);
+
+  const handleSubmit = (form: EquipmentFormData) => {
+    if (editingId) {
+      update.mutate({ id: editingId, data: form }, { onSuccess: () => setOpened(false) });
+    } else {
+      create.mutate(form, { onSuccess: () => setOpened(false) });
+    }
+  };
+
+  return (
+    <Stack p="lg">
+      <Group justify="space-between" mb="md">
+        <Title order={1}>Equipamentos</Title>
+        <Button onClick={() => { setEditingId(null); setOpened(true); }}>Novo</Button>
+      </Group>
+      {isLoading && <Text>Carregando...</Text>}
+      {data && (
+        <Table striped withTableBorder highlightOnHover>
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>Nome</Table.Th>
+              <Table.Th>Modelo</Table.Th>
+              <Table.Th>TAG</Table.Th>
+              <Table.Th>Localização</Table.Th>
+              <Table.Th>BTUs</Table.Th>
+              <Table.Th />
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {data.map((eq) => (
+              <Table.Tr key={eq.id}>
+                <Table.Td>{eq.name}</Table.Td>
+                <Table.Td>{eq.model}</Table.Td>
+                <Table.Td>{eq.tag}</Table.Td>
+                <Table.Td>{eq.location}</Table.Td>
+                <Table.Td>{eq.btus}</Table.Td>
+                <Table.Td>
+                  <Group gap="xs" justify="flex-end">
+                    <Button size="xs" onClick={() => { setEditingId(eq.id); setOpened(true); }}>
+                      Editar
+                    </Button>
+                    <Button
+                      size="xs"
+                      color="red"
+                      onClick={() => remove.mutate(eq.id)}
+                    >
+                      Remover
+                    </Button>
+                  </Group>
+                </Table.Td>
+              </Table.Tr>
+            ))}
+          </Table.Tbody>
+        </Table>
+      )}
+      <Modal opened={opened} onClose={() => setOpened(false)} title="Equipamento">
+        <EquipamentoForm
+          initialValues={editingItem ?? undefined}
+          onSubmit={handleSubmit}
+          onCancel={() => setOpened(false)}
+        />
+      </Modal>
+    </Stack>
+  );
+};
+
+export default EquipamentosPage;

--- a/frontend/src/modules/assets/presentation/__tests__/Equipamentos.test.tsx
+++ b/frontend/src/modules/assets/presentation/__tests__/Equipamentos.test.tsx
@@ -1,0 +1,19 @@
+import { render, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import EquipamentosPage from '../EquipamentosPage';
+import ClimaTrakThemeProvider from '../../../../providers/ClimaTrakThemeProvider';
+
+const queryClient = new QueryClient();
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>
+    <ClimaTrakThemeProvider>{children}</ClimaTrakThemeProvider>
+  </QueryClientProvider>
+);
+
+test('renders list and can open form', async () => {
+  const { getByText } = render(<EquipamentosPage />, { wrapper: Wrapper });
+  expect(getByText('Equipamentos')).toBeInTheDocument();
+  fireEvent.click(getByText('Novo'));
+  expect(getByText('Salvar')).toBeInTheDocument();
+});

--- a/frontend/src/modules/assets/schemas/equipmentSchema.ts
+++ b/frontend/src/modules/assets/schemas/equipmentSchema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const equipmentSchema = z.object({
+  name: z.string().nonempty('Nome é obrigatório'),
+  model: z.string().nonempty('Modelo é obrigatório'),
+  tag: z.string().nonempty('TAG é obrigatória'),
+  location: z.string().nonempty('Localização é obrigatória'),
+  btus: z
+    .number({ invalid_type_error: 'BTUs deve ser um número' })
+    .positive('BTUs deve ser positivo'),
+});
+
+export type EquipmentFormData = z.infer<typeof equipmentSchema>;

--- a/frontend/src/presentation/components/layout/TopNav.tsx
+++ b/frontend/src/presentation/components/layout/TopNav.tsx
@@ -17,7 +17,7 @@ import { useDisclosure, useMediaQuery } from '@mantine/hooks';
 
 const links = [
   { label: 'Visão Geral', to: '/app/overview' },
-  { label: 'Ativos', to: '/app/assets' },
+  { label: 'Equipamentos', to: '/app/equipamentos' },
   { label: 'Ordens de Serviço', to: '/app/work-orders' },
   { label: 'Planos', to: '/app/plans' },
   { label: 'Métricas', to: '/app/metrics' },

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,7 +1,7 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
 import AppLayout from '../presentation/components/layout/AppLayout';
 import Overview from '../presentation/pages/Overview';
-import Assets from '../presentation/pages/Assets';
+import EquipamentosPage from '../modules/assets/presentation/EquipamentosPage';
 import WorkOrders from '../presentation/pages/WorkOrders';
 import Plans from '../presentation/pages/Plans';
 import Metrics from '../presentation/pages/Metrics';
@@ -26,7 +26,7 @@ const Router = () => {
       >
         <Route index element={<DashboardPage />} />
         <Route path="overview" element={<Overview />} />
-        <Route path="assets" element={<Assets />} />
+        <Route path="equipamentos" element={<EquipamentosPage />} />
         <Route path="work-orders" element={<WorkOrders />} />
         <Route path="plans" element={<Plans />} />
         <Route path="metrics" element={<Metrics />} />


### PR DESCRIPTION
## Summary
- add new Equipamentos module with domain, infrastructure, application and presentation layers
- wire QueryClient provider and route for `/app/equipamentos`
- update TopNav with Equipamentos link
- add basic tests for the new page

## Testing
- `pnpm lint` *(fails: ESLint couldn't find config)*
- `pnpm test` *(fails: jest not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68564a73a2b0832c8ca058128613d8e4