### PR TITLE
Update docs with local run guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ pnpm dev
 
 The application will be available at http://localhost:5173 showing **Hello ClimaTrak**.
 
+For a detailed step-by-step guide on running the project locally, see [docs/rodando-localmente.md](docs/rodando-localmente.md).
+
 ## Como rodar
 
 1. Execute `pnpm install` na raiz do repositório para instalar as dependências.

--- a/docs/rodando-localmente.md
+++ b/docs/rodando-localmente.md
@@ -1,0 +1,42 @@
+# Guia Rápido para Rodar Localmente
+
+Este documento descreve passo a passo como executar a aplicação front-end do ClimaTrak em ambiente de desenvolvimento.
+
+## 1. Requisitos
+
+- **Node.js** 16 ou superior
+- **pnpm** como gerenciador de pacotes
+- **Git** para clonar o repositório
+
+## 2. Clonar e instalar dependências
+
+```bash
+git clone <url-do-repositorio>
+cd traknor-frontend
+pnpm install
+```
+
+Se já possui o projeto clonado, atualize as dependências com:
+
+```bash
+pnpm update
+```
+
+## 3. Iniciar o servidor de desenvolvimento
+
+```bash
+pnpm dev
+```
+
+A aplicação ficará disponível em `http://localhost:5173`.
+
+## 4. Conferência de código
+
+Antes de enviar um pull request, execute:
+
+```bash
+pnpm lint
+pnpm test
+```
+
+Caso seja um projeto Python, também rode `pytest` e crie migrações quando modificar models.

--- a/docs/setup-vscode.md
+++ b/docs/setup-vscode.md
@@ -24,6 +24,12 @@ Instale todas as dependências utilizando o pnpm:
 pnpm install
 ```
 
+Para garantir que as bibliotecas permaneçam atualizadas, rode periodicamente:
+
+```bash
+pnpm update
+```
+
 Se estiver contribuindo com o projeto, execute também:
 
 ```bash


### PR DESCRIPTION
## Summary
- add a Portuguese guide for running the project locally
- reference new doc in README
- document `pnpm update` in VSCode setup

## Testing
- `pnpm --filter frontend run lint` *(fails: ESLint config not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68564c1864a0832c9f5cc79ce752d566