### PR TITLE
Add user management module

### DIFF
--- a/frontend/src/domain/auth.ts
+++ b/frontend/src/domain/auth.ts
@@ -1,7 +1,10 @@
+export type Role = 'ADMIN' | 'TECH' | 'CLIENT';
+
 export interface User {
   id: number;
   email: string;
   name: string;
+  role: Role;
 }
 
 export interface AuthState {

--- a/frontend/src/modules/users/application/useUsers.ts
+++ b/frontend/src/modules/users/application/useUsers.ts
@@ -1,0 +1,29 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import UserService from '../infrastructure/UserService';
+import { UserInput } from '../domain/user';
+
+export const useUsers = () => {
+  const queryClient = useQueryClient();
+  const listQuery = useQuery({
+    queryKey: ['users'],
+    queryFn: () => UserService.list(),
+  });
+
+  const create = useMutation({
+    mutationFn: (data: UserInput) => UserService.create(data),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['users'] }),
+  });
+
+  const update = useMutation({
+    mutationFn: ({ id, data }: { id: number; data: Partial<UserInput> }) =>
+      UserService.update(id, data),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['users'] }),
+  });
+
+  const toggleActive = useMutation({
+    mutationFn: (id: number) => UserService.toggleActive(id),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['users'] }),
+  });
+
+  return { ...listQuery, create, update, toggleActive };
+};

--- a/frontend/src/modules/users/domain/user.ts
+++ b/frontend/src/modules/users/domain/user.ts
@@ -1,0 +1,16 @@
+import { UserRole } from '../schemas/userSchema';
+
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+  role: UserRole;
+  active: boolean;
+}
+
+export interface UserInput {
+  name: string;
+  email: string;
+  password: string;
+  role: UserRole;
+}

--- a/frontend/src/modules/users/infrastructure/UserService.ts
+++ b/frontend/src/modules/users/infrastructure/UserService.ts
@@ -1,0 +1,51 @@
+import { User, UserInput } from '../domain/user';
+
+let users: User[] = [
+  { id: 1, name: 'Admin', email: 'admin@example.com', role: 'ADMIN', active: true },
+  { id: 2, name: 'Técnico', email: 'tech@example.com', role: 'TECH', active: true },
+  { id: 3, name: 'Cliente', email: 'client@example.com', role: 'CLIENT', active: true },
+];
+
+const delay = () => new Promise((r) => setTimeout(r, 100));
+
+const UserService = {
+  async list(): Promise<User[]> {
+    await delay();
+    return users;
+  },
+  async create(data: UserInput): Promise<User> {
+    await delay();
+    const exists = users.some((u) => u.email === data.email);
+    if (exists) {
+      const err = new Error('E-mail já em uso');
+      // @ts-ignore
+      err.status = 422;
+      throw err;
+    }
+    const newUser: User = { id: Date.now(), active: true, ...data };
+    users.push(newUser);
+    return newUser;
+  },
+  async update(id: number, data: Partial<UserInput>): Promise<User> {
+    await delay();
+    const idx = users.findIndex((u) => u.id === id);
+    if (idx === -1) throw new Error('Not found');
+    if (data.email && users.some((u) => u.email === data.email && u.id !== id)) {
+      const err = new Error('E-mail já em uso');
+      // @ts-ignore
+      err.status = 422;
+      throw err;
+    }
+    users[idx] = { ...users[idx], ...data } as User;
+    return users[idx];
+  },
+  async toggleActive(id: number): Promise<void> {
+    await delay();
+    const idx = users.findIndex((u) => u.id === id);
+    if (idx !== -1) {
+      users[idx].active = !users[idx].active;
+    }
+  },
+};
+
+export default UserService;

--- a/frontend/src/modules/users/presentation/UsuarioForm.tsx
+++ b/frontend/src/modules/users/presentation/UsuarioForm.tsx
@@ -1,0 +1,47 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Button, Group, PasswordInput, Select, TextInput } from '@mantine/core';
+import { useForm } from 'react-hook-form';
+import { UserFormData, userSchema, roleEnum } from '../schemas/userSchema';
+
+interface Props {
+  initialValues?: Partial<UserFormData>;
+  onSubmit: (data: UserFormData) => void;
+  onCancel: () => void;
+}
+
+const UsuarioForm = ({ initialValues, onSubmit, onCancel }: Props) => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<UserFormData>({
+    resolver: zodResolver(userSchema),
+    defaultValues: initialValues,
+  });
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-2">
+      <TextInput label="Nome" {...register('name')} error={errors.name?.message} />
+      <TextInput label="E-mail" {...register('email')} error={errors.email?.message} />
+      <PasswordInput
+        label="Senha"
+        {...register('password')}
+        error={errors.password?.message}
+      />
+      <Select
+        label="Papel"
+        data={roleEnum.options}
+        {...register('role')}
+        error={errors.role?.message}
+      />
+      <Group justify="flex-end" mt="md">
+        <Button variant="outline" onClick={onCancel} type="button">
+          Cancelar
+        </Button>
+        <Button type="submit">Salvar</Button>
+      </Group>
+    </form>
+  );
+};
+
+export default UsuarioForm;

--- a/frontend/src/modules/users/presentation/UsuariosPage.tsx
+++ b/frontend/src/modules/users/presentation/UsuariosPage.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+import { Button, Group, Modal, Stack, Table, Text, Title } from '@mantine/core';
+import { useUsers } from '../application/useUsers';
+import UsuarioForm from './UsuarioForm';
+import { UserFormData } from '../schemas/userSchema';
+
+const UsuariosPage = () => {
+  const { data, isLoading, create, update, toggleActive } = useUsers();
+  const [opened, setOpened] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+
+  const editingItem = data?.find((u) => u.id === editingId);
+
+  const handleSubmit = (form: UserFormData) => {
+    if (editingId) {
+      update.mutate({ id: editingId, data: form }, { onSuccess: () => setOpened(false) });
+    } else {
+      create.mutate(form, { onSuccess: () => setOpened(false) });
+    }
+  };
+
+  return (
+    <Stack p="lg">
+      <Group justify="space-between" mb="md">
+        <Title order={1}>Usuários</Title>
+        <Button onClick={() => { setEditingId(null); setOpened(true); }}>Novo</Button>
+      </Group>
+      {isLoading && <Text>Carregando...</Text>}
+      {data && (
+        <Table striped withTableBorder highlightOnHover>
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>Nome</Table.Th>
+              <Table.Th>E-mail</Table.Th>
+              <Table.Th>Papel</Table.Th>
+              <Table.Th>Status</Table.Th>
+              <Table.Th />
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {data.map((u) => (
+              <Table.Tr key={u.id}>
+                <Table.Td>{u.name}</Table.Td>
+                <Table.Td>{u.email}</Table.Td>
+                <Table.Td>{u.role}</Table.Td>
+                <Table.Td>{u.active ? 'Ativo' : 'Inativo'}</Table.Td>
+                <Table.Td>
+                  <Group gap="xs" justify="flex-end">
+                    <Button size="xs" onClick={() => { setEditingId(u.id); setOpened(true); }}>
+                      Editar
+                    </Button>
+                    <Button
+                      size="xs"
+                      color={u.active ? 'red' : 'green'}
+                      onClick={() => toggleActive.mutate(u.id)}
+                    >
+                      {u.active ? 'Desativar' : 'Ativar'}
+                    </Button>
+                  </Group>
+                </Table.Td>
+              </Table.Tr>
+            ))}
+          </Table.Tbody>
+        </Table>
+      )}
+      <Modal opened={opened} onClose={() => setOpened(false)} title="Usuário">
+        <UsuarioForm
+          initialValues={editingItem ?? undefined}
+          onSubmit={handleSubmit}
+          onCancel={() => setOpened(false)}
+        />
+      </Modal>
+    </Stack>
+  );
+};
+
+export default UsuariosPage;

--- a/frontend/src/modules/users/presentation/__tests__/Usuarios.test.tsx
+++ b/frontend/src/modules/users/presentation/__tests__/Usuarios.test.tsx
@@ -1,0 +1,19 @@
+import { render, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import UsuariosPage from '../UsuariosPage';
+import ClimaTrakThemeProvider from '../../../../providers/ClimaTrakThemeProvider';
+
+const queryClient = new QueryClient();
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>
+    <ClimaTrakThemeProvider>{children}</ClimaTrakThemeProvider>
+  </QueryClientProvider>
+);
+
+test('renders list and can open form', async () => {
+  const { getByText } = render(<UsuariosPage />, { wrapper: Wrapper });
+  expect(getByText('Usuários')).toBeInTheDocument();
+  fireEvent.click(getByText('Novo'));
+  expect(getByText('Salvar')).toBeInTheDocument();
+});

--- a/frontend/src/modules/users/schemas/userSchema.ts
+++ b/frontend/src/modules/users/schemas/userSchema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const roleEnum = z.enum(['ADMIN', 'TECH', 'CLIENT']);
+
+export const userSchema = z.object({
+  name: z.string().nonempty('Nome é obrigatório'),
+  email: z.string().email('E-mail inválido'),
+  password: z.string().min(6, 'Senha obrigatória'),
+  role: roleEnum,
+});
+
+export type UserFormData = z.infer<typeof userSchema>;
+export type UserRole = z.infer<typeof roleEnum>;

--- a/frontend/src/presentation/components/layout/TopNav.tsx
+++ b/frontend/src/presentation/components/layout/TopNav.tsx
@@ -14,14 +14,16 @@ import {
   useMantineTheme,
 } from '@mantine/core';
 import { useDisclosure, useMediaQuery } from '@mantine/hooks';
+import { useAuthStore } from '../../../stores/useAuthStore';
 
-const links = [
-  { label: 'Visão Geral', to: '/app/overview' },
-  { label: 'Equipamentos', to: '/app/equipamentos' },
-  { label: 'Ordens de Serviço', to: '/app/work-orders' },
-  { label: 'Planos', to: '/app/plans' },
-  { label: 'Métricas', to: '/app/metrics' },
-  { label: 'Relatórios', to: '/app/reports' },
+const baseLinks = [
+  { label: 'Visão Geral', to: '/app/overview', roles: ['ADMIN', 'TECH', 'CLIENT'] },
+  { label: 'Equipamentos', to: '/app/equipamentos', roles: ['ADMIN', 'TECH', 'CLIENT'] },
+  { label: 'Usuários', to: '/app/usuarios', roles: ['ADMIN'] },
+  { label: 'Ordens de Serviço', to: '/app/work-orders', roles: ['ADMIN', 'TECH'] },
+  { label: 'Planos', to: '/app/plans', roles: ['ADMIN'] },
+  { label: 'Métricas', to: '/app/metrics', roles: ['ADMIN'] },
+  { label: 'Relatórios', to: '/app/reports', roles: ['ADMIN', 'CLIENT'] },
 ];
 
 const TopNav = () => {
@@ -29,6 +31,8 @@ const TopNav = () => {
   const [opened, { toggle, close }] = useDisclosure(false);
   const isMobile = useMediaQuery(`(max-width: ${theme.breakpoints.md})`);
   const [module, setModule] = useState('TrakNor');
+  const role = useAuthStore((s) => s.user?.role ?? 'CLIENT');
+  const links = baseLinks.filter((l) => l.roles.includes(role));
 
   const items = links.map((link) => (
     <Button

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import AppLayout from '../presentation/components/layout/AppLayout';
 import Overview from '../presentation/pages/Overview';
 import EquipamentosPage from '../modules/assets/presentation/EquipamentosPage';
+import UsuariosPage from '../modules/users/presentation/UsuariosPage';
 import WorkOrders from '../presentation/pages/WorkOrders';
 import Plans from '../presentation/pages/Plans';
 import Metrics from '../presentation/pages/Metrics';
@@ -27,6 +28,7 @@ const Router = () => {
         <Route index element={<DashboardPage />} />
         <Route path="overview" element={<Overview />} />
         <Route path="equipamentos" element={<EquipamentosPage />} />
+        <Route path="usuarios" element={<UsuariosPage />} />
         <Route path="work-orders" element={<WorkOrders />} />
         <Route path="plans" element={<Plans />} />
         <Route path="metrics" element={<Metrics />} />

--- a/frontend/src/services/AuthService.ts
+++ b/frontend/src/services/AuthService.ts
@@ -9,6 +9,7 @@ export interface LoginResponse {
     id: number;
     email: string;
     name: string;
+    role: 'ADMIN' | 'TECH' | 'CLIENT';
   };
 }
 
@@ -18,7 +19,7 @@ const AuthService = {
     if (password === 'password') {
       return {
         token: 'mock-token',
-        user: { id: 1, email, name: 'Usuário' },
+        user: { id: 1, email, name: 'Usuário', role: 'ADMIN' },
       };
     }
     throw new Error('Credenciais inválidas');


### PR DESCRIPTION
## Summary
- implement users module following Clean Architecture
- add role-based authentication data
- integrate UsuariosPage via routes
- show menu links according to user role

## Testing
- `pnpm lint` *(fails: node_modules missing)*
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68564df859e0832ca75a074d168a5865