### PR TITLE
feat: add api layer with axios and auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -32,3 +32,19 @@ pnpm lint
 pnpm format
 pnpm format:check
 ```
+
+## Camada de API & Auth
+
+Todas as chamadas HTTP utilizam a instância `api` configurada em `src/infrastructure/api/axios.ts`. Antes de consumir, defina `VITE_API_URL` no `.env` apontando para o backend.
+
+Exemplo de login e chamada autenticada:
+
+```ts
+import { login } from '@/infrastructure/api/auth';
+import { api } from '@/infrastructure/api/axios';
+
+await login({ username: 'alice', password: '123' });
+const dados = await api.get('/api/dashboard/');
+```
+
+Tokens são salvos em `localStorage` e renovados automaticamente.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext .ts,.tsx",
-    "test": "jest --config jest.config.ts"
+    "test": "vitest run"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",
@@ -18,7 +18,8 @@
     "react-hook-form": "^7.58.1",
     "react-router-dom": "^6.23.1",
     "zod": "^3.25.67",
-    "zustand": "^5.0.5"
+    "zustand": "^5.0.5",
+    "axios": "^1.6.7"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",
@@ -45,6 +46,9 @@
     "ts-jest": "^29.1.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "openapi-typescript": "^6.6.4",
+    "vitest": "^1.5.0",
+    "msw": "^2.2.1"
   }
 }

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -1,0 +1,47 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useState,
+  type ReactNode,
+} from 'react';
+import { login as apiLogin, logout as apiLogout } from '@/infrastructure/api/auth';
+import { tokenStore } from '@/utils/tokenStorage';
+
+interface Credentials { username: string; password: string; }
+
+interface AuthContextValue {
+  access: string | null;
+  refresh: string | null;
+  login: (c: Credentials) => Promise<void>;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [access, setAccess] = useState<string | null>(tokenStore.access);
+  const [refresh, setRefresh] = useState<string | null>(tokenStore.refresh);
+
+  const login = useCallback(async (cred: Credentials) => {
+    const { access: a, refresh: r } = await apiLogin(cred);
+    setAccess(a);
+    setRefresh(r);
+  }, []);
+
+  const logout = useCallback(() => {
+    apiLogout();
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ access, refresh, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be inside AuthProvider');
+  return ctx;
+}

--- a/frontend/src/infrastructure/api/auth.ts
+++ b/frontend/src/infrastructure/api/auth.ts
@@ -1,0 +1,23 @@
+import { api } from './axios';
+import { tokenStore } from '@/utils/tokenStorage';
+
+interface LoginDTO { username: string; password: string; }
+interface TokenPair { access: string; refresh: string; }
+
+export async function login(payload: LoginDTO): Promise<TokenPair> {
+  const { data } = await api.post<TokenPair>('/api/auth/login/', payload);
+  tokenStore.set(data.access, data.refresh);
+  return data;
+}
+
+export async function refreshToken(): Promise<TokenPair> {
+  const { data } = await api.post<TokenPair>('/api/auth/refresh/', {
+    refresh: tokenStore.refresh,
+  });
+  return data;
+}
+
+export function logout() {
+  tokenStore.clear();
+  window.location.href = '/login';
+}

--- a/frontend/src/infrastructure/api/axios.ts
+++ b/frontend/src/infrastructure/api/axios.ts
@@ -1,0 +1,41 @@
+import axios, { AxiosError } from 'axios';
+import { tokenStore } from '@/utils/tokenStorage';
+import { refreshToken, logout } from './auth';
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL,
+  timeout: 10_000,
+});
+
+api.interceptors.request.use((config) => {
+  const access = tokenStore.access;
+  if (access) {
+    // eslint-disable-next-line no-param-reassign
+    (config.headers ||= {}).Authorization = `Bearer ${access}`;
+  }
+  return config;
+});
+
+api.interceptors.response.use(
+  (res) => res,
+  async (error: AxiosError) => {
+    const original: any = error.config;
+    if (error.response?.status === 401 && !original?._retry) {
+      original._retry = true;
+      try {
+        const { access, refresh } = await refreshToken();
+        tokenStore.set(access, refresh);
+        return api(original);
+      } catch {
+        logout();
+        return Promise.reject(error);
+      }
+    }
+    if (error.response?.status === 403) {
+      logout();
+    }
+    return Promise.reject(error);
+  },
+);
+
+export { api };

--- a/frontend/src/utils/tokenStorage.ts
+++ b/frontend/src/utils/tokenStorage.ts
@@ -1,0 +1,15 @@
+const ACCESS_KEY = 'tk_access';
+const REFRESH_KEY = 'tk_refresh';
+
+export const tokenStore = {
+  get access() { return localStorage.getItem(ACCESS_KEY); },
+  get refresh() { return localStorage.getItem(REFRESH_KEY); },
+  set(access: string, refresh: string) {
+    localStorage.setItem(ACCESS_KEY, access);
+    localStorage.setItem(REFRESH_KEY, refresh);
+  },
+  clear() {
+    localStorage.removeItem(ACCESS_KEY);
+    localStorage.removeItem(REFRESH_KEY);
+  },
+};

--- a/frontend/tests/components/StatCard.test.tsx
+++ b/frontend/tests/components/StatCard.test.tsx
@@ -1,18 +1,22 @@
 import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
 import StatCard from '../../src/presentation/components/StatCard';
 import ClimaTrakThemeProvider from '../../src/providers/ClimaTrakThemeProvider';
 
-it('renders value and icon', () => {
-  const { getByText, getByTestId } = render(
-    <ClimaTrakThemeProvider>
-      <StatCard
-        label="OS"
-        value={5}
-        statusColor="blue"
-        icon={<span data-testid="icon">i</span>}
-      />
-    </ClimaTrakThemeProvider>,
-  );
-  expect(getByText('5')).toBeInTheDocument();
-  expect(getByTestId('icon')).toBeInTheDocument();
+describe('StatCard', () => {
+  it('renders value and icon', () => {
+    const { getByText, getByTestId } = render(
+      <ClimaTrakThemeProvider>
+        <StatCard
+          label="OS"
+          value={5}
+          statusColor="blue"
+          icon={<span data-testid="icon">i</span>}
+        />
+      </ClimaTrakThemeProvider>,
+    );
+    expect(getByText('5')).toBeInTheDocument();
+    expect(getByTestId('icon')).toBeInTheDocument();
+  });
 });
+

--- a/frontend/tests/components/TopNav.test.tsx
+++ b/frontend/tests/components/TopNav.test.tsx
@@ -1,13 +1,16 @@
 import { render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect } from 'vitest';
 import TopNav from '../../src/presentation/components/layout/TopNav';
 
-it('renders main links and avatar', () => {
-  const { getByText } = render(
-    <MemoryRouter>
-      <TopNav />
-    </MemoryRouter>,
-  );
-  expect(getByText('Visão Geral')).toBeInTheDocument();
-  expect(getByText('U')).toBeInTheDocument();
+describe('TopNav', () => {
+  it('renders main links and avatar', () => {
+    const { getByText } = render(
+      <MemoryRouter>
+        <TopNav />
+      </MemoryRouter>,
+    );
+    expect(getByText('Visão Geral')).toBeInTheDocument();
+    expect(getByText('U')).toBeInTheDocument();
+  });
 });

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: { '@': path.resolve(__dirname, 'src') },
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: './setupTests.ts',
+    coverage: {
+      reporter: ['text', 'json', 'html'],
+      include: ['src/infrastructure/api/**/*.{ts,tsx}'],
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   ],
   "scripts": {
     "lint": "pnpm --filter frontend run lint",
-    "test": "pnpm --filter frontend run test"
+    "test": "pnpm --filter frontend run test",
+    "api:gen": "openapi-typescript http://localhost:8000/schema/openapi.json -o frontend/src/infrastructure/api/types/generated.ts"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",

--- a/tests/api/auth.spec.ts
+++ b/tests/api/auth.spec.ts
@@ -1,0 +1,45 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { api } from '../../frontend/src/infrastructure/api/axios';
+import { login } from '../../frontend/src/infrastructure/api/auth';
+import { tokenStore } from '../../frontend/src/utils/tokenStorage';
+
+const server = setupServer(
+  rest.post('http://localhost:8000/api/auth/login/', (_req, res, ctx) =>
+    res(ctx.json({ access: 'a1', refresh: 'r1' })),
+  ),
+  rest.post('http://localhost:8000/api/auth/refresh/', (_req, res, ctx) =>
+    res(ctx.json({ access: 'a2', refresh: 'r2' })),
+  ),
+);
+
+beforeAll(() => server.listen());
+afterEach(() => {
+  server.resetHandlers();
+  tokenStore.clear();
+});
+afterAll(() => server.close());
+
+describe('auth api', () => {
+  it('login stores tokens', async () => {
+    await login({ username: 'u', password: 'p' });
+    expect(tokenStore.access).toBe('a1');
+    expect(tokenStore.refresh).toBe('r1');
+  });
+
+  it('refresh interceptor replays request', async () => {
+    tokenStore.set('old', 'r1');
+    let calls = 0;
+    server.use(
+      rest.get('http://localhost:8000/test', (_req, res, ctx) => {
+        calls += 1;
+        if (calls === 1) return res(ctx.status(401));
+        return res(ctx.json({ ok: true }));
+      }),
+    );
+    await api.get('/test');
+    expect(calls).toBe(2);
+    expect(tokenStore.access).toBe('a2');
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "paths": {
       "@/*": ["./*"]
     },
-    "types": ["jest"]
+    "types": []
   },
   "include": [
     "frontend/src",


### PR DESCRIPTION
## Contexto
Cria camada de API no frontend seguindo definição da issue.

## Mudanças
- instancia Axios com token e fluxo de refresh
- funções de autenticação e armazenamento de tokens
- hook `useAuth` com contexto
- testes em Vitest usando msw
- script `api:gen` e exemplo no README

## Como testar
1. `pnpm lint && pnpm test`
2. `pnpm build`



------
https://chatgpt.com/codex/tasks/task_e_6858a59fe8b0832cb711ab5a970002de