### PR TITLE
feat(Reports): SB23-report-downloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
 - Lista e detalhe de Ordens de Serviço com transições de status
 - Suporte a mirror de registry npm via `.npmrc` (Closes #27)
 - Dashboard KPIs com auto-refresh (Closes #26)
+- Exporta relatórios em PDF ou Excel pela página `/reports` (Closes #27)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ For a detailed step-by-step guide on running the project locally, see [docs/roda
 3. Abra `http://localhost:5173` no navegador e verifique se a página inicial é exibida sem erros.
 
 ## Problemas de Registry
+
 Se sua rede bloquear `registry.npmjs.org`, defina:
+
 ```bash
 export NPM_REGISTRY=https://registry.npmmirror.com
 pnpm install
@@ -93,3 +95,7 @@ A partir da rota `/app/work-orders` é possível visualizar uma caixa de entrada
 ## Dashboard KPIs
 
 A página `/dashboard` exibe indicadores-chave de manutenção (MTTR, MTBF e contagem de ordens de serviço) em cartões visuais. Os valores são atualizados automaticamente a cada 60 segundos utilizando **@tanstack/react-query**.
+
+## Relatórios
+
+A página `/reports` permite gerar relatórios em PDF ou Excel dos equipamentos ou ordens de serviço. Selecione o tipo e formato desejados e clique em **Download** para iniciar a geração. Um toast informa o andamento e o arquivo é salvo automaticamente.

--- a/docs/openapi/reports.yaml
+++ b/docs/openapi/reports.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.0
+info:
+  title: Reports API
+  version: 1.0.0
+paths:
+  /api/reports/:
+    get:
+      parameters:
+        - in: query
+          name: type
+          schema:
+            type: string
+            enum: [equipment, workorder]
+          required: true
+        - in: query
+          name: format
+          schema:
+            type: string
+            enum: [pdf, xlsx]
+          required: true
+      responses:
+        "200":
+          description: Report file
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary

--- a/frontend/src/components/Layout/Navbar.tsx
+++ b/frontend/src/components/Layout/Navbar.tsx
@@ -1,6 +1,15 @@
 import { NavLink } from 'react-router-dom';
 import { Navbar as MantineNavbar, Stack } from '@mantine/core';
-import { IconHome2, IconDeviceDesktopAnalytics, IconClipboardList, IconFileText, IconListCheck, IconUsers, IconReportAnalytics, IconGauge } from '@mantine/icons-react';
+import {
+  IconHome2,
+  IconDeviceDesktopAnalytics,
+  IconClipboardList,
+  IconFileText,
+  IconListCheck,
+  IconUsers,
+  IconReportAnalytics,
+  IconGauge,
+} from '@mantine/icons-react';
 
 const menu = [
   { label: 'Visão Geral', icon: IconGauge, to: '/' },
@@ -10,7 +19,7 @@ const menu = [
   { label: 'Planos', icon: IconListCheck, to: '/planos' },
   { label: 'Métricas', icon: IconHome2, to: '/metricas' },
   { label: 'Usuários', icon: IconUsers, to: '/usuarios' },
-  { label: 'Relatórios', icon: IconReportAnalytics, to: '/relatorios' },
+  { label: 'Relatórios', icon: IconReportAnalytics, to: '/reports' },
 ];
 
 const Navbar = () => (

--- a/frontend/src/modules/reports/application/useDownloadReport.ts
+++ b/frontend/src/modules/reports/application/useDownloadReport.ts
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { api } from '@/infrastructure/api/axios';
+import { showNotification } from '@mantine/notifications';
+import { saveAs } from 'file-saver';
+import type { ReportType, ReportFormat } from '../domain/report';
+
+const useDownloadReport = () => {
+  const [isFetching, setIsFetching] = useState(false);
+
+  const download = async (type: ReportType, format: ReportFormat) => {
+    const id = `report-${Date.now()}`;
+    showNotification({ id, message: 'Gerando relatório…', loading: true });
+    try {
+      setIsFetching(true);
+      const { data } = await api.get<Blob>('/api/reports/', {
+        params: { type, format },
+        responseType: 'blob',
+      });
+      saveAs(data, `report-${type}.${format}`);
+      showNotification({ id, message: 'Relatório baixado', color: 'green' });
+    } catch {
+      showNotification({
+        id,
+        message: 'Falha ao gerar relatório',
+        color: 'red',
+      });
+    } finally {
+      setIsFetching(false);
+    }
+  };
+
+  return { download, isFetching };
+};
+
+export default useDownloadReport;

--- a/frontend/src/modules/reports/domain/report.ts
+++ b/frontend/src/modules/reports/domain/report.ts
@@ -1,0 +1,2 @@
+export type ReportType = 'equipment' | 'workorder';
+export type ReportFormat = 'pdf' | 'xlsx';

--- a/frontend/src/pages/Reports/ReportDownloader.stories.tsx
+++ b/frontend/src/pages/Reports/ReportDownloader.stories.tsx
@@ -1,0 +1,11 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ReportDownloader from './ReportDownloader';
+
+const meta: Meta<typeof ReportDownloader> = {
+  title: 'Pages/ReportDownloader',
+  component: ReportDownloader,
+};
+
+export default meta;
+
+export const Basic: StoryObj<typeof ReportDownloader> = {};

--- a/frontend/src/pages/Reports/ReportDownloader.tsx
+++ b/frontend/src/pages/Reports/ReportDownloader.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { Stack, Button, Select } from '@mantine/core';
+import { IconDownload } from '@mantine/icons-react';
+import type { ReportType, ReportFormat } from '@/modules/reports/domain/report';
+import useDownloadReport from '@/modules/reports/application/useDownloadReport';
+
+const typeOptions = [
+  { value: 'equipment', label: 'Equipamentos' },
+  { value: 'workorder', label: 'Ordens de Serviço' },
+];
+
+const formatOptions = [
+  { value: 'pdf', label: 'PDF' },
+  { value: 'xlsx', label: 'Excel' },
+];
+
+const ReportDownloader = () => {
+  const [type, setType] = useState<ReportType | ''>('');
+  const [format, setFormat] = useState<ReportFormat | ''>('');
+  const { download, isFetching } = useDownloadReport();
+
+  const handleDownload = () => {
+    if (type && format) {
+      download(type, format);
+    }
+  };
+
+  return (
+    <Stack maw={320}>
+      <Select
+        label="Tipo"
+        placeholder="Selecione"
+        data={typeOptions}
+        value={type}
+        onChange={(val) => setType(val as ReportType)}
+        disabled={isFetching}
+        allowDeselect
+      />
+      <Select
+        label="Formato"
+        placeholder="Selecione"
+        data={formatOptions}
+        value={format}
+        onChange={(val) => setFormat(val as ReportFormat)}
+        disabled={isFetching}
+        allowDeselect
+      />
+      <Button
+        leftSection={<IconDownload size={16} />}
+        disabled={!type || !format}
+        loading={isFetching}
+        onClick={handleDownload}
+      >
+        Download
+      </Button>
+    </Stack>
+  );
+};
+
+export default ReportDownloader;

--- a/frontend/src/pages/Reports/index.ts
+++ b/frontend/src/pages/Reports/index.ts
@@ -1,0 +1,2 @@
+import ReportDownloader from './ReportDownloader';
+export default ReportDownloader;

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -1,7 +1,12 @@
-import { RouteObject, createBrowserRouter, RouterProvider } from 'react-router-dom';
+import {
+  RouteObject,
+  createBrowserRouter,
+  RouterProvider,
+} from 'react-router-dom';
 import AppShell from './components/Layout/AppShell';
 import StubPage from './pages/StubPage';
 import DashboardView from './pages/Dashboard/DashboardView';
+import ReportDownloader from './pages/Reports/ReportDownloader';
 
 const routes: RouteObject[] = [
   {
@@ -16,7 +21,7 @@ const routes: RouteObject[] = [
       { path: 'planos', element: <StubPage title="Planos" /> },
       { path: 'metricas', element: <StubPage title="Métricas" /> },
       { path: 'usuarios', element: <StubPage title="Usuários" /> },
-      { path: 'relatorios', element: <StubPage title="Relatórios" /> },
+      { path: 'reports', element: <ReportDownloader /> },
     ],
   },
 ];

--- a/tests/reports.spec.tsx
+++ b/tests/reports.spec.tsx
@@ -1,0 +1,73 @@
+import {
+  describe,
+  it,
+  beforeAll,
+  afterEach,
+  afterAll,
+  vi,
+  expect,
+} from "vitest";
+import { rest } from "msw";
+import { setupServer } from "msw/node";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, fireEvent, waitFor } from "@testing-library/react";
+import ReportDownloader from "../frontend/src/pages/Reports/ReportDownloader";
+import { saveAs } from "file-saver";
+import { showNotification } from "@mantine/notifications";
+
+vi.mock("file-saver", () => ({ saveAs: vi.fn() }));
+vi.mock("@mantine/notifications", () => ({ showNotification: vi.fn() }));
+
+const server = setupServer(
+  rest.get("http://localhost:8000/api/reports/", (_req, res, ctx) =>
+    res(ctx.body("dummy")),
+  ),
+);
+
+beforeAll(() => server.listen());
+afterEach(() => {
+  server.resetHandlers();
+  vi.clearAllMocks();
+});
+afterAll(() => server.close());
+
+describe("ReportDownloader", () => {
+  it("downloads report successfully", async () => {
+    const qc = new QueryClient();
+    const { getByText, getAllByRole } = render(
+      <QueryClientProvider client={qc}>
+        <ReportDownloader />
+      </QueryClientProvider>,
+    );
+    fireEvent.change(getAllByRole("combobox")[0], {
+      target: { value: "equipment" },
+    });
+    fireEvent.change(getAllByRole("combobox")[1], { target: { value: "pdf" } });
+    fireEvent.click(getByText("Download"));
+    await waitFor(() => expect(saveAs).toHaveBeenCalled());
+  });
+
+  it("shows error notification on failure", async () => {
+    server.use(
+      rest.get("http://localhost:8000/api/reports/", (_req, res, ctx) =>
+        res(ctx.status(500)),
+      ),
+    );
+    const qc = new QueryClient();
+    const { getByText, getAllByRole } = render(
+      <QueryClientProvider client={qc}>
+        <ReportDownloader />
+      </QueryClientProvider>,
+    );
+    fireEvent.change(getAllByRole("combobox")[0], {
+      target: { value: "equipment" },
+    });
+    fireEvent.change(getAllByRole("combobox")[1], { target: { value: "pdf" } });
+    fireEvent.click(getByText("Download"));
+    await waitFor(() =>
+      expect(showNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ color: "red" }),
+      ),
+    );
+  });
+});


### PR DESCRIPTION
## Contexto
Implementa página de download de relatórios conforme sprint SB23.

## Mudanças
- Nova rota `/reports` com seleção de tipo e formato
- Hook `useDownloadReport` para chamada ao endpoint e feedback com toasts
- Storybook e testes usando MSW simulam sucesso e erro
- Atualização da navbar, README e CHANGELOG
- Documentação do endpoint em `docs/openapi/reports.yaml`

## Como testar
1. Navegue até `/reports`
2. Escolha tipo e formato e clique em **Download**
3. Verifique toast de progresso e arquivo salvo.

### CI
- `pnpm lint` e `pnpm test` falharam nesta execução por ausência de dependências


------
https://chatgpt.com/codex/tasks/task_e_6858b94fa608832c9f4451dde07ee9d8