### PR TITLE
chore(Test): SB25-test-coverage-frontend

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -29,8 +29,8 @@ jobs:
         run: pnpm api:check
       - name: Lint
         run: pnpm lint
-      - name: Test
-        run: pnpm test
+      - name: Run unit tests with coverage
+        run: pnpm test:coverage
       - name: Build
         run: pnpm --filter frontend build
       - name: Build Storybook

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,3 +3,4 @@
 
 pnpm install --frozen-lockfile
 pnpm api:check
+pnpm test:coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@
 - Dashboard KPIs com auto-refresh (Closes #26)
 - Exporta relatórios em PDF ou Excel pela página `/reports` (Closes #27)
 - Controle de acesso por papéis com `<RoleRoute>` e página de erro 403 (Closes #28)
+- Configura Vitest e React Testing Library com cobertura mínima de 80% (Closes #29)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ pnpm format
 pnpm format:check
 ```
 
+## Rodando Testes
+
+Execute a suíte de testes e gere o relatório de cobertura com:
+
+```bash
+pnpm test:coverage
+```
+
+Commits e builds falham se a cobertura ficar abaixo de 80%.
+
 ## Camada de API & Auth
 
 Todas as chamadas HTTP utilizam a instância `api` configurada em `src/infrastructure/api/axios.ts`. Antes de consumir, defina `VITE_API_URL` no `.env` apontando para o backend.

--- a/frontend/src/__tests__/smoke.spec.tsx
+++ b/frontend/src/__tests__/smoke.spec.tsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react';
+import App from '@/App';
+
+test('renders hello', () => {
+  render(<App />);
+  expect(screen.getByText(/climatrak/i)).toBeInTheDocument();
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   ],
   "scripts": {
     "lint": "pnpm --filter frontend run lint",
-    "test": "pnpm --filter frontend run test",
+    "test": "vitest",
+    "test:coverage": "vitest run --coverage",
     "api:gen": "openapi-typescript $VITE_API_URL/schema/ -o frontend/src/api/generated/schemas.ts && openapi-typescript-codegen --client axios -o frontend/src/api/generated --useOptions --useUnionTypes $VITE_API_URL/schema/",
     "api:check": "pnpm api:gen && git diff --exit-code",
     "preinstall": "npx only-allow pnpm",
@@ -32,6 +33,13 @@
     "openapi-typescript": "^6.6.4",
     "openapi-typescript-codegen": "^0.30.1",
     "husky": "^9.0.11",
-    "axios": "^1.6.7"
+    "axios": "^1.6.7",
+    "vitest": "^1.5.0",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.4.3",
+    "jsdom": "^22.1.0",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react-hooks": "^0.1.0",
+    "@vitest/coverage-c8": "^0.4.0"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    coverage: {
+      provider: 'c8',
+      all: true,
+      lines: 80,
+      branches: 80,
+      functions: 80,
+      statements: 80,
+      reporter: ['text', 'lcov'],
+    },
+  },
+});


### PR DESCRIPTION
• Configura **Vitest + React-Testing-Library** como stack oficial de testes do frontend
• Adiciona meta de **≥ 80 %** de cobertura (lines/branches/functions/statements) – build e PR falham se abaixo do alvo
• Integra execução e gate de cobertura no Husky (pre-commit) e no GitHub Actions
• Closes #29

## Contexto
Implementa infraestrutura de testes automatizados com Vitest, garantindo cobertura mínima de 80% e integração no pipeline de CI e no pre-commit.

## Mudanças
- Adiciona `vitest.config.ts` na raiz com thresholds de cobertura
- Atualiza scripts de teste no `package.json` e adiciona dependências de teste
- Garante execução de `pnpm test:coverage` no pre-commit e no workflow do GitHub
- Cria teste `smoke.spec.tsx` para manter cobertura inicial
- Documenta como rodar testes no README
- Atualiza CHANGELOG

## Como testar
1. `pnpm test:coverage` – gera relatório com meta ≥ 80%
2. Commit falhará se cobertura abaixo do limite
3. Pipeline do GitHub Actions executa testes com cobertura


------
https://chatgpt.com/codex/tasks/task_e_6858bf4ba908832c96d9223990c99536