### PR TITLE
chore(CI): SB31-fix-ci-workflow-install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - develop
+      - "feat/**"
+      - "fix/**"
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+          run_install: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - name: Restore pnpm store
+        uses: actions/cache@v3
+        with:
+          path: ~/.pnpm-store
+          key: pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+      - run: pnpm test:coverage
+      - run: pnpm --filter frontend build


### PR DESCRIPTION
## Contexto
Corrige workflow principal de CI que falhava ao instalar dependências.

## Mudanças
- Adiciona `pnpm/action-setup` e `actions/setup-node` ao job
- Usa cache do store PNPM e instala dependências com `--frozen-lockfile`
- Executa lint, testes e build do frontend

## Como testar
- Verifique que o novo workflow `ci.yml` instala pacotes utilizando Node 20 e pnpm 8
- CI deverá rodar `pnpm lint`, `pnpm test:coverage` e `pnpm --filter frontend build` sem erros


------
https://chatgpt.com/codex/tasks/task_e_6858c8612300832cb858d65347f280be