### PR TITLE
chore(DevEx): SB32-precommit-ci-skip

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,11 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
+if [ "$CI" = "true" ]; then
+  echo "CI detected – skipping local-only checks"
+  exit 0
+fi
+
 if ! grep -q "VITE_API_URL=" .env 2>/dev/null; then
   echo "❌ VITE_API_URL não configurado em .env" >&2
   exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,4 @@
 - Controle de acesso por papéis com `<RoleRoute>` e página de erro 403 (Closes #28)
 - Configura Vitest e React Testing Library com cobertura mínima de 80% (Closes #29)
 - Setup local de frontend com proxy e script `setup.sh` (SB30)
+- Hook pre-commit ignora etapas locais no CI (Closes #32)


### PR DESCRIPTION
• Ajusta hook *pre-commit* para pular verificações quando `$CI=true`
• Evita falhas artificiais no GitHub Actions mantendo rigor local
• Closes #32

---

## Contexto
Este PR insere uma verificação no hook `pre-commit` que detecta quando está rodando em ambiente de CI e interrompe a execução dos passos locais (lint e testes). Assim evitamos falhas em pipelines que não possuem `.env` ou dependências instaladas, mantendo o mesmo comportamento no desenvolvimento local.

## Mudanças
- Inclusão do `if [ "$CI" = "true" ]` no início do script `.husky/pre-commit`
- Registro da mudança no `CHANGELOG.md`

## Como testar
1. Defina `CI=true` e execute `git commit --allow-empty -m test` – o hook deve ser ignorado.
2. Sem `CI=true`, o hook continua rodando `pnpm lint` e `pnpm test` normalmente (dependências necessárias).


------
https://chatgpt.com/codex/tasks/task_e_6858c960bdf0832ca7edf3ea321a6237