### PR TITLE
chore(Build): SB33-move-vite-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,3 +18,4 @@
 - Configura Vitest e React Testing Library com cobertura mínima de 80% (Closes #29)
 - Setup local de frontend com proxy e script `setup.sh` (SB30)
 - Hook pre-commit ignora etapas locais no CI (Closes #32)
+- Move `vite.config.ts` para a raiz e atualiza scripts `dev`/`build` (Closes #33)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Install dependencies and start the dev server from the repository root:
 ```bash
 pnpm install
 pnpm dev
+# Se preferir manter o arquivo em `frontend/vite.config.ts`, rode:
+# vite --config frontend/vite.config.ts
 ```
 
 The application will be available at http://localhost:5173 showing **Hello ClimaTrak**.

--- a/docs/rodando-localmente.md
+++ b/docs/rodando-localmente.md
@@ -27,6 +27,8 @@ pnpm update
 
 ```bash
 pnpm dev
+# Se optar por manter `vite.config.ts` dentro de `frontend`, utilize:
+# vite --config frontend/vite.config.ts
 ```
 
 A aplicação ficará disponível em `http://localhost:5173`.

--- a/frontend/.eslintignore
+++ b/frontend/.eslintignore
@@ -1,3 +1,3 @@
 cypress.config.ts
 jest.config.ts
-vite.config.ts
+../vite.config.ts

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -5,5 +5,5 @@
     "moduleResolution": "Node",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["../vite.config.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "frontend"
   ],
   "scripts": {
+    "dev": "pnpm --filter frontend exec vite -- --config vite.config.ts",
+    "build": "pnpm --filter frontend exec vite build -- --config vite.config.ts",
     "lint": "pnpm --filter frontend run lint",
     "format": "pnpm --filter frontend run format",
     "perf": "react-codemod --analysis",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import react from '@vitejs/plugin-react';
 import path from 'path';
 
 export default defineConfig({
+  root: path.resolve(__dirname, 'frontend'),
   plugins: [react()],
   server: {
     proxy: {
@@ -15,7 +16,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, 'src'),
+      '@': path.resolve(__dirname, 'frontend/src'),
     },
   },
 });


### PR DESCRIPTION
• Move `vite.config.ts` para a raiz do monorepo e atualiza scripts `dev`/`build`
• Documenta opção alternativa: `vite --config frontend/vite.config.ts` caso prefira manter estrutura atual
• Closes #33

------
https://chatgpt.com/codex/tasks/task_e_6858d01ec268832c91ef61e9d5b74db1