### PR TITLE
chore(DevEx): SB34-setup-sh-windows-compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,3 +19,4 @@
 - Setup local de frontend com proxy e script `setup.sh` (SB30)
 - Hook pre-commit ignora etapas locais no CI (Closes #32)
 - Move `vite.config.ts` para a raiz e atualiza scripts `dev`/`build` (Closes #33)
+- Torna `setup.sh` compatível com Windows usando corepack e `pnpm env` (Closes #34)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For a detailed step-by-step guide on running the project locally, see [docs/roda
 
 ### Pré-requisitos
 
-- Node 20 gerenciado via [nvm](https://github.com/nvm-sh/nvm)
+ - Node 20 via [nvm](https://github.com/nvm-sh/nvm) (Linux/Mac) ou `pnpm env` (Windows)
 - pnpm
 
 ### Passo a passo

--- a/docs/rodando-localmente.md
+++ b/docs/rodando-localmente.md
@@ -4,7 +4,7 @@ Este documento descreve passo a passo como executar a aplicação front-end do C
 
 ## 1. Requisitos
 
-- **Node.js** 16 ou superior
+ - **Node.js** 20 (via nvm no Linux/Mac ou `pnpm env` no Windows)
 - **pnpm** como gerenciador de pacotes
 - **Git** para clonar o repositório
 

--- a/docs/setup-vscode.md
+++ b/docs/setup-vscode.md
@@ -4,7 +4,7 @@ Este documento descreve os passos para clonar e executar o front-end do projeto 
 
 ## 1. Requisitos
 
-- **Node.js** 16 ou superior
+ - **Node.js** 20 (via nvm no Linux/Mac ou `pnpm env` no Windows)
 - **pnpm** (gerenciador de pacotes)
 - **Git** para clonar o repositório
 - (Opcional) Extensão _ESLint_ no VS Code para feedback de lint em tempo real

--- a/setup.sh
+++ b/setup.sh
@@ -8,15 +8,23 @@ for arg in "$@"; do
   fi
 done
 
+OS=$(uname -o 2>/dev/null || echo "unknown")
 NODE_VERSION=20
-if command -v nvm >/dev/null; then
-  source "$(command -v nvm | sed 's/bin\/nvm$/nvm.sh/')"
+
+if echo "$OS" | grep -qi 'mingw'; then
+  echo "Windows detected – using corepack instead of nvm"
+  corepack enable pnpm
+  pnpm env use --global "$NODE_VERSION"
 else
-  curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
-  source "$HOME/.nvm/nvm.sh"
+  if command -v nvm >/dev/null; then
+    source "$(command -v nvm | sed 's/bin\/nvm$/nvm.sh/')"
+  else
+    curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+    source "$HOME/.nvm/nvm.sh"
+  fi
+  nvm install "$NODE_VERSION"
+  nvm use "$NODE_VERSION"
 fi
-nvm install "$NODE_VERSION"
-nvm use "$NODE_VERSION"
 
 echo "🔧 Using Node $(node -v)"
 


### PR DESCRIPTION
## Contexto
Ajusta o script de setup para funcionar em ambientes Windows, permitindo o uso via Git Bash ou WSL.

## Mudanças
- Detecta Windows via `uname -o` e utiliza `corepack` + `pnpm env` quando `nvm` não está disponível
- Atualiza README e docs de desenvolvimento com instruções para Windows
- Registra melhoria no `CHANGELOG`

## Como testar
1. Execute `./setup.sh` em ambientes Linux/Mac e Windows (Git Bash ou WSL)
2. Verifique a instalação do Node 20 e das dependências sem erros


------
https://chatgpt.com/codex/tasks/task_e_6858d4ee22d4832cb8c0d4a88e03af32