### PR TITLE
chore(Docker): SB36-dockerize-frontend

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -1,0 +1,18 @@
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  location / {
+    try_files $uri /index.html;
+  }
+
+  location /api/ {
+    proxy_pass http://backend:8000/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+}

--- a/.github/workflows/docker-smoke.yml
+++ b/.github/workflows/docker-smoke.yml
@@ -1,0 +1,17 @@
+name: docker-smoke
+
+on:
+  pull_request:
+    paths:
+      - Dockerfile
+      - docker-compose.yml
+      - '.docker/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build compose services
+        run: docker compose build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@
 - Move `vite.config.ts` para a raiz e atualiza scripts `dev`/`build` (Closes #33)
 - Torna `setup.sh` compatível com Windows usando corepack e `pnpm env` (Closes #34)
 - Workflow CI executa lint e testes automatizados (Closes #35)
+- Dockerfile multi-stage e exemplo `docker-compose.yml` para rodar frontend e backend (Closes #36)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package.json pnpm-lock.yaml ./
+COPY frontend ./frontend
+COPY vite.config.ts ./
+RUN corepack enable && corepack prepare pnpm@8 --activate
+RUN pnpm install --frozen-lockfile
+ARG VITE_API_URL=/api
+ENV VITE_API_URL=$VITE_API_URL
+RUN pnpm build
+
+FROM nginx:1.25-alpine
+COPY --from=builder /app/frontend/dist /usr/share/nginx/html
+COPY .docker/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ export NPM_REGISTRY=https://registry.npmmirror.com
 pnpm install
 ```
 
+## Rodando tudo em Docker
+
+Para subir frontend e backend de exemplo com um único comando, execute:
+
+```bash
+docker compose up --build
+```
+
+A aplicação ficará acessível em `http://localhost:3000`. O Nginx do container
+redireciona requisições `\*/api` para o serviço `backend` na porta 8000.
+
 ### Formatting and Linting
 
 For instructions on setting up the project in Visual Studio Code, see [docs/setup-vscode.md](docs/setup-vscode.md).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.9'
+services:
+  backend:
+    image: ghcr.io/climatrak/traknor-backend:latest
+    ports:
+      - "8000:8000"
+  frontend:
+    build:
+      context: .
+    environment:
+      - VITE_API_URL=/api
+    ports:
+      - "3000:80"
+    depends_on:
+      - backend


### PR DESCRIPTION
• Adiciona Dockerfile multi-stage (Node 20 → Nginx) e proxy /api para container backend
• Cria exemplo `docker-compose.yml` que orquestra frontend + backend para dev ou demo
• Atualiza README com instruções `docker compose up --build`
• Closes #36

## Objetivo
Permitir que qualquer colaborador suba TrakNor end-to-end com um único comando Docker, validando comunicação da API sem configurar ambiente local Node ou Python.


------
https://chatgpt.com/codex/tasks/task_e_6859c172e9a4832c8a06f2bc17b648b0