### PR TITLE
fix: register typescript eslint plugin

### DIFF
--- a/frontend/eslint.config.cjs
+++ b/frontend/eslint.config.cjs
@@ -1,13 +1,19 @@
 // frontend/eslint.config.cjs
 /** @type {import('eslint').FlatConfig[]} */
-const { configs: { recommended: eslintRecommended } } = require("eslint");
-const { configs: { recommended: tsRecommended, "recommended-requiring-type-checking": tsTypeChecked } } = require("@typescript-eslint/eslint-plugin");
+const { configs: { recommended: eslintRecommended } } = require("@eslint/js");
+const tsPlugin = require("@typescript-eslint/eslint-plugin");
 const tsParser = require("@typescript-eslint/parser");
-const { configs: { recommended: reactRecommended } } = require("eslint-plugin-react");
-const { configs: { recommended: jsxA11yRecommended } } = require("eslint-plugin-jsx-a11y");
-const { configs: { recommended: reactHooksRecommended } } = require("eslint-plugin-react-hooks");
-const { configs: { recommended: importRecommended } } = require("eslint-plugin-import");
-const { configs: { "prettier-recommended": prettierRecommended } } = require("eslint-plugin-prettier");
+const reactPlugin = require("eslint-plugin-react");
+const jsxA11yPlugin = require("eslint-plugin-jsx-a11y");
+const reactHooksPlugin = require("eslint-plugin-react-hooks");
+const importPlugin = require("eslint-plugin-import");
+const prettierPlugin = require("eslint-plugin-prettier");
+const { configs: { recommended: tsRecommended, "recommended-requiring-type-checking": tsTypeChecked } } = tsPlugin;
+const { configs: { recommended: reactRecommended } } = reactPlugin;
+const { configs: { recommended: jsxA11yRecommended } } = jsxA11yPlugin;
+const { configs: { recommended: reactHooksRecommended } } = reactHooksPlugin;
+const { configs: { recommended: importRecommended } } = importPlugin;
+const { configs: { recommended: prettierRecommended } } = prettierPlugin;
 
 module.exports = [
   // ESLint core
@@ -15,7 +21,8 @@ module.exports = [
 
   // TS basic
   {
-    ...tsRecommended,
+    plugins: { "@typescript-eslint": tsPlugin },
+    rules: tsRecommended.rules,
     languageOptions: {
       parser: tsParser,
       parserOptions: {
@@ -30,7 +37,8 @@ module.exports = [
 
   // TS com type-checking
   {
-    ...tsTypeChecked,
+    plugins: { "@typescript-eslint": tsPlugin },
+    rules: tsTypeChecked.rules,
     languageOptions: {
       parser: tsParser,
       parserOptions: {
@@ -42,25 +50,40 @@ module.exports = [
 
   // React
   {
-    ...reactRecommended,
-    settings: { react: { version: "detect" } },
+    plugins: { react: reactPlugin },
     rules: { ...reactRecommended.rules, "react/react-in-jsx-scope": "off" },
+    languageOptions: { parserOptions: reactRecommended.parserOptions },
+    settings: { react: { version: "detect" } },
   },
 
   // A11y
-  jsxA11yRecommended,
+  {
+    plugins: { "jsx-a11y": jsxA11yPlugin },
+    rules: jsxA11yRecommended.rules,
+    languageOptions: {
+      parserOptions: jsxA11yRecommended.parserOptions,
+    },
+  },
 
   // Hooks
-  reactHooksRecommended,
+  {
+    plugins: { "react-hooks": reactHooksPlugin },
+    rules: reactHooksRecommended.rules,
+  },
 
   // Import
   {
-    ...importRecommended,
+    plugins: { import: importPlugin },
+    rules: importRecommended.rules,
+    languageOptions: { parserOptions: importRecommended.parserOptions },
     settings: { "import/resolver": { typescript: {} } },
   },
 
   // Prettier
-  prettierRecommended,
+  {
+    plugins: { prettier: prettierPlugin },
+    rules: prettierRecommended.rules,
+  },
 
   // ignores e patterns
   {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "zustand": "^5.0.5"
   },
   "devDependencies": {
+    "@eslint/js": "^9.29.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^14.3.1",
     "@testing-library/user-event": "^14.6.1",
@@ -48,12 +49,12 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-unused-imports": "^4.1.4",
-    "typescript-eslint": "^7.8.0",
     "jsdom": "^26.1.0",
     "msw": "^2.2.1",
     "prettier": "^3.6.0",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
+    "typescript-eslint": "^7.8.0",
     "vite": "^5.3.0",
     "vitest": "^3.2.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5(@types/react@18.3.23)(react@18.3.1)
     devDependencies:
+      '@eslint/js':
+        specifier: ^9.29.0
+        version: 9.29.0
       '@testing-library/jest-dom':
         specifier: ^6.6.3
         version: 6.6.3
@@ -3587,7 +3590,7 @@ snapshots:
       '@babel/traverse': 7.27.4
       '@babel/types': 7.27.6
       convert-source-map: 2.0.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@10.0.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -3668,7 +3671,7 @@ snapshots:
       '@babel/parser': 7.27.5
       '@babel/template': 7.27.2
       '@babel/types': 7.27.6
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@10.0.0)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -3820,7 +3823,7 @@ snapshots:
   '@eslint/config-array@0.20.1':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@10.0.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -3838,7 +3841,7 @@ snapshots:
   '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@10.0.0)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -4264,7 +4267,7 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@10.0.0)
       eslint: 9.29.0(jiti@1.21.7)
     optionalDependencies:
       typescript: 5.8.3
@@ -4277,7 +4280,7 @@ snapshots:
       '@typescript-eslint/types': 8.35.0
       '@typescript-eslint/typescript-estree': 8.35.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.35.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@10.0.0)
       eslint: 9.29.0(jiti@1.21.7)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -4287,7 +4290,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.35.0(typescript@5.8.3)
       '@typescript-eslint/types': 8.35.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@10.0.0)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -4310,7 +4313,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.8.3)
       '@typescript-eslint/utils': 7.18.0(eslint@9.29.0(jiti@1.21.7))(typescript@5.8.3)
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@10.0.0)
       eslint: 9.29.0(jiti@1.21.7)
       ts-api-utils: 1.4.3(typescript@5.8.3)
     optionalDependencies:
@@ -4322,7 +4325,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.35.0(typescript@5.8.3)
       '@typescript-eslint/utils': 8.35.0(eslint@9.29.0(jiti@1.21.7))(typescript@5.8.3)
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@10.0.0)
       eslint: 9.29.0(jiti@1.21.7)
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
@@ -4337,7 +4340,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@10.0.0)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -4354,7 +4357,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.35.0(typescript@5.8.3)
       '@typescript-eslint/types': 8.35.0
       '@typescript-eslint/visitor-keys': 8.35.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@10.0.0)
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -4413,7 +4416,7 @@ snapshots:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
       ast-v8-to-istanbul: 0.3.3
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@10.0.0)
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6
@@ -5334,7 +5337,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@10.0.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -5654,7 +5657,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@10.0.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5663,13 +5666,6 @@ snapshots:
       assert-plus: 1.0.0
       jsprim: 2.0.2
       sshpk: 1.18.0
-
-  https-proxy-agent@7.0.6:
-    dependencies:
-      agent-base: 7.1.3
-      debug: 4.4.1(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
 
   https-proxy-agent@7.0.6(supports-color@10.0.0):
     dependencies:
@@ -5863,7 +5859,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.6:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@10.0.0)
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -5909,7 +5905,7 @@ snapshots:
       decimal.js: 10.5.0
       html-encoding-sniffer: 4.0.0
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@10.0.0)
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.20
       parse5: 7.3.0
@@ -7087,7 +7083,7 @@ snapshots:
   vite-node@3.2.4(@types/node@24.0.4):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@10.0.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 5.4.19(@types/node@24.0.4)
@@ -7122,7 +7118,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.2.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@10.0.0)
       expect-type: 1.2.1
       magic-string: 0.30.17
       pathe: 2.0.3


### PR DESCRIPTION
## Contexto
A execução do `pnpm lint` falhava pois o arquivo `eslint.config.cjs` aplicava regras do `@typescript-eslint` sem registrar o plugin correspondente.

## Mudanças
- Adicionado `@eslint/js` às dependências de desenvolvimento.
- Atualizado `eslint.config.cjs` para registrar todos os plugins utilizados e ajustar as opções de linguagem.

## Como testar
1. Instale as dependências com `pnpm install`.
2. Execute `pnpm lint` e verifique que o erro de *plugin not found* não ocorre mais (apesar de ainda haver erros de lint no projeto).


------
https://chatgpt.com/codex/tasks/task_e_685dd17bf9c4832cb09a38092ee93d67