### PR TITLE
chore(frontend): migrate layout components to Mantine 8 AppShell

### DIFF
--- a/docs/migration/mantine-v8.md
+++ b/docs/migration/mantine-v8.md
@@ -1,0 +1,15 @@
+# Mantine 8 Migration
+
+Este projeto foi atualizado para o Mantine 8.1.2.
+
+Os componentes de layout `Header`, `Navbar`, `Footer` e `Aside` foram removidos do export principal do `@mantine/core` e agora devem ser acessados via `AppShell`.
+
+Para facilitar a migração foi criado o codemod `scripts/mantine-v8-appshell-codemod.js`.
+
+Execute o comando abaixo a partir da raiz do repositório para refatorar automaticamente os arquivos:
+
+```bash
+npx jscodeshift -t scripts/mantine-v8-appshell-codemod.js frontend/src --extensions=ts,tsx --parser=tsx
+```
+
+Referência: [Mantine AppShell Guide](https://mantine.dev/guides/app-shell/#compound-components)

--- a/frontend/src/components/Layout/Header.tsx
+++ b/frontend/src/components/Layout/Header.tsx
@@ -2,7 +2,7 @@ import {
   ActionIcon,
   Burger,
   Group,
-  Header as MantineHeader,
+  AppShell,
   Title,
 } from '@mantine/core';
 import {
@@ -20,7 +20,7 @@ interface Props {
 }
 
 const Header = ({ opened, toggle, colorScheme, toggleColorScheme }: Props) => (
-  <MantineHeader height={64} px="md">
+  <AppShell.Header height={64} px="md">
     <Group h="100%" justify="space-between">
       <Group>
         <Burger
@@ -50,7 +50,7 @@ const Header = ({ opened, toggle, colorScheme, toggleColorScheme }: Props) => (
         </ActionIcon>
       </Group>
     </Group>
-  </MantineHeader>
+  </AppShell.Header>
 );
 
 export default Header;

--- a/frontend/src/components/Layout/Navbar.tsx
+++ b/frontend/src/components/Layout/Navbar.tsx
@@ -1,5 +1,5 @@
 import { NavLink } from 'react-router-dom';
-import { Navbar as MantineNavbar, Stack } from '@mantine/core';
+import { AppShell, Stack } from '@mantine/core';
 import {
   IconHome2,
   IconDeviceDesktopAnalytics,
@@ -23,8 +23,8 @@ const menu = [
 ];
 
 const Navbar = () => (
-  <MantineNavbar width={{ base: 200 }} p="md">
-    <MantineNavbar.Section grow component={Stack} gap="xs">
+  <AppShell.Navbar width={{ base: 200 }} p="md">
+    <AppShell.Navbar.Section grow component={Stack} gap="xs">
       {menu.map((item) => (
         <NavLink
           key={item.to}
@@ -40,8 +40,8 @@ const Navbar = () => (
           {item.label}
         </NavLink>
       ))}
-    </MantineNavbar.Section>
-  </MantineNavbar>
+    </AppShell.Navbar.Section>
+  </AppShell.Navbar>
 );
 
 export default Navbar;

--- a/frontend/src/presentation/components/layout/TopNav.tsx
+++ b/frontend/src/presentation/components/layout/TopNav.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { NavLink } from 'react-router-dom';
 import {
-  Header,
+  AppShell,
   Group,
   Burger,
   Drawer,
@@ -63,7 +63,7 @@ const TopNav = () => {
   ));
 
   return (
-    <Header height={64} className="bg-[#002d2b] text-gray-200">
+    <AppShell.Header height={64} className="bg-[#002d2b] text-gray-200">
       <Group justify="space-between" h="100%" px="md">
         <Group gap="sm">
           {isMobile && (
@@ -106,7 +106,7 @@ const TopNav = () => {
       <Drawer opened={opened} onClose={close} padding="md" size="xs">
         <Stack>{items}</Stack>
       </Drawer>
-    </Header>
+    </AppShell.Header>
   );
 };
 

--- a/frontend/src/providers/ClimaTrakThemeProvider.tsx
+++ b/frontend/src/providers/ClimaTrakThemeProvider.tsx
@@ -1,7 +1,6 @@
 import { ReactNode, useState, useEffect } from 'react';
 import {
   MantineProvider,
-  ColorSchemeProvider,
   ColorScheme,
   createTheme,
 } from '@mantine/core';
@@ -38,19 +37,14 @@ const ClimaTrakThemeProvider = ({ children }: Props) => {
     });
 
   return (
-    <ColorSchemeProvider
+    <MantineProvider
+      theme={theme}
+      withGlobalStyles
+      withNormalizeCSS
       colorScheme={colorScheme}
-      toggleColorScheme={toggleColorScheme}
     >
-      <MantineProvider
-        theme={theme}
-        withGlobalStyles
-        withNormalizeCSS
-        colorScheme={colorScheme}
-      >
-        {children}
-      </MantineProvider>
-    </ColorSchemeProvider>
+      {children}
+    </MantineProvider>
   );
 };
 

--- a/scripts/mantine-v8-appshell-codemod.js
+++ b/scripts/mantine-v8-appshell-codemod.js
@@ -1,0 +1,48 @@
+module.exports = function transformer(fileInfo, api) {
+  const j = api.jscodeshift;
+  const root = j(fileInfo.source);
+  let needsAppShell = false;
+
+  // 1) Ajustar imports
+  root
+    .find(j.ImportDeclaration, { source: { value: '@mantine/core' } })
+    .forEach(path => {
+      path.value.specifiers = path.value.specifiers.filter(spec => {
+        const name = spec.imported?.name;
+        if (['Header', 'Navbar', 'Footer', 'Aside'].includes(name)) {
+          needsAppShell = true;
+          return false;
+        }
+        return true;
+      });
+
+      if (needsAppShell) {
+        const hasAppShell = path.value.specifiers.some(
+          spec => spec.imported?.name === 'AppShell',
+        );
+        if (!hasAppShell) {
+          path.value.specifiers.push(j.importSpecifier(j.identifier('AppShell')));
+        }
+      }
+    });
+
+  // 2) Substituir tags JSX
+  ['Header', 'Navbar', 'Footer', 'Aside'].forEach(tag => {
+    root.findJSXElements(tag).forEach(path => {
+      const node = path.node;
+      node.openingElement.name = j.jsxMemberExpression(
+        j.jsxIdentifier('AppShell'),
+        j.jsxIdentifier(tag),
+      );
+      if (node.closingElement) {
+        node.closingElement.name = j.jsxMemberExpression(
+          j.jsxIdentifier('AppShell'),
+          j.jsxIdentifier(tag),
+        );
+      }
+      needsAppShell = true;
+    });
+  });
+
+  return root.toSource();
+};


### PR DESCRIPTION
## Summary
- create codemod to replace removed layout components with `AppShell` compound components
- update local layout components and TopNav to use `AppShell`
- adjust theme provider for Mantine 8
- add migration notes for Mantine 8

## Testing
- `pnpm run build`
- `./frontend/run-frontend.sh` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68614eef9fd8832cab6b38da542459bc