### PR TITLE
Fix navbar icon imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,6 @@
 - Dockerfile multi-stage e exemplo `docker-compose.yml` para rodar frontend e backend (Closes #36)
 - Corrige dependências e configurações do frontend garantindo build sem erros (Closes #67)
 - Otimiza Dockerfile, adiciona `.dockerignore`, rede dedicada e verificação no CI (SB37)
+
+### Fixed
+- navbar import errors

--- a/frontend/src/components/Layout/AppShell.tsx
+++ b/frontend/src/components/Layout/AppShell.tsx
@@ -5,7 +5,7 @@ import {
 } from '@mantine/core';
 import { Outlet } from 'react-router-dom';
 import Header from './Header';
-import Navbar from './Navbar';
+import { Navbar } from './Navbar';
 
 const AppShell = () => {
   const [opened, { toggle }] = useDisclosure();

--- a/frontend/src/components/Layout/Navbar.tsx
+++ b/frontend/src/components/Layout/Navbar.tsx
@@ -22,7 +22,7 @@ const menu = [
   { label: 'Relatórios', icon: IconReportAnalytics, to: '/reports' },
 ];
 
-const Navbar = () => (
+export const Navbar = () => (
   <AppShell.Navbar width={{ base: 200 }} p="md">
     <AppShell.Navbar.Section grow component={Stack} gap="xs">
       {menu.map((item) => (
@@ -43,5 +43,3 @@ const Navbar = () => (
     </AppShell.Navbar.Section>
   </AppShell.Navbar>
 );
-
-export default Navbar;


### PR DESCRIPTION
## Summary
- fix Navbar export
- update import in AppShell
- note fix in CHANGELOG

## Testing
- `pnpm exec eslint src/components/Layout/Navbar.tsx`
- `pnpm exec tsc --noEmit` *(fails: Could not find a declaration file for module 'react/jsx-runtime')*
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_6861d58d0fb0832cb990ff3f4bc96984