### PR TITLE
Fix navbar exports

### DIFF
--- a/frontend/src/components/Layout/index.ts
+++ b/frontend/src/components/Layout/index.ts
@@ -1,0 +1,3 @@
+export { default as AppShell } from './AppShell';
+export { default as Header } from './Header';
+export { default as Navbar } from './Navbar';

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,0 +1,2 @@
+export * from './Layout';
+export * from './routes';

--- a/frontend/src/components/routes/index.ts
+++ b/frontend/src/components/routes/index.ts
@@ -1,0 +1,3 @@
+export { default as AuthGuard } from './AuthGuard';
+export { default as PrivateRoute } from './PrivateRoute';
+export { default as ProtectedRoute } from './ProtectedRoute';

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -5,7 +5,7 @@ import {
 } from 'react-router-dom';
 import { Suspense, lazy } from 'react';
 import { Loader } from '@mantine/core';
-import AppShell from './components/Layout/AppShell';
+import { AppShell } from './components';
 const StubPage = lazy(() => import('./pages/StubPage'));
 const DashboardView = lazy(() => import('./pages/Dashboard/DashboardView'));
 const ReportDownloader = lazy(() => import('./pages/Reports/ReportDownloader'));


### PR DESCRIPTION
## Summary
- add index files for Layout and route components
- re-export components from a central index
- fix router import to use the new index

## Testing
- `pnpm --filter frontend run build`
- `pnpm tsc --noEmit --strict` *(fails: Property 'env' does not exist on type 'ImportMeta', etc.)*
- `pnpm dev`


------
https://chatgpt.com/codex/tasks/task_e_6861dc618a1c832c8f0c1429e7d4dc5e