### PR TITLE
Fix auth provider not initialized

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
 import ClimaTrakThemeProvider from './providers/ClimaTrakThemeProvider';
+import { AuthProvider } from './hooks/useAuth';
 import './index.css';
 
 const queryClient = new QueryClient();
@@ -10,9 +11,11 @@ const queryClient = new QueryClient();
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <ClimaTrakThemeProvider>
-        <App />
-      </ClimaTrakThemeProvider>
+      <AuthProvider>
+        <ClimaTrakThemeProvider>
+          <App />
+        </ClimaTrakThemeProvider>
+      </AuthProvider>
     </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -11,8 +11,10 @@ const DashboardView = lazy(() => import('./pages/Dashboard/DashboardView'));
 const ReportDownloader = lazy(() => import('./pages/Reports/ReportDownloader'));
 import RoleRoute from './router/RoleRoute';
 const Forbidden = lazy(() => import('./pages/Error/Forbidden'));
+const Login = lazy(() => import('./presentation/pages/Auth/Login'));
 
 const routes: RouteObject[] = [
+  { path: 'login', element: <Login /> },
   {
     path: '/',
     element: <AppShell />,


### PR DESCRIPTION
## Summary
- ensure auth context is available by wrapping `<App>` with `AuthProvider`
- expose login page via `/login` route

## Testing
- `pnpm --filter frontend run dev` *(fails: @hookform/resolvers/zod missing)*

------
https://chatgpt.com/codex/tasks/task_e_68646d629c58832c9696eec0ca19eedf