### PR TITLE
Fix router reference and datatable imports

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.1.1",
     "@mantine/core": "^8.1.2",
     "@mantine/hooks": "^8.1.2",
     "@mantine/notifications": "^8.1.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.1.1
+        version: 5.1.1(react-hook-form@7.59.0(react@18.3.1))
       '@mantine/core':
         specifier: ^8.1.2
         version: 8.1.2(@mantine/hooks@8.1.2(react@18.3.1))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -487,6 +490,11 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
+  '@hookform/resolvers@5.1.1':
+    resolution: {integrity: sha512-J/NVING3LMAEvexJkyTLjruSm7aOFx7QX21pzkiJfMoNG0wl5aFEjLTl7ay7IQb9EWY6AkrBy7tHL2Alijpdcg==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -731,6 +739,9 @@ packages:
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@tabler/icons-react@2.47.0':
     resolution: {integrity: sha512-iqly2FvCF/qUbgmvS8E40rVeYY7laltc5GUjRxQj59DuX0x/6CpKHTXt86YlI2whg4czvd/c8Ce8YR08uEku0g==}
@@ -3773,6 +3784,11 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
+  '@hookform/resolvers@5.1.1(react-hook-form@7.59.0(react@18.3.1))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.59.0(react@18.3.1)
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -3971,6 +3987,8 @@ snapshots:
     optional: true
 
   '@rtsao/scc@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@tabler/icons-react@2.47.0(react@18.3.1)':
     dependencies:

--- a/frontend/src/pages/Equipment/EquipmentTable.tsx
+++ b/frontend/src/pages/Equipment/EquipmentTable.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, memo, useCallback } from 'react';
 import { Button, Group, Loader, Stack, ActionIcon } from '@mantine/core';
 import { IconTrash } from '@tabler/icons-react';
-import { MantineDataTable } from '@mantine/datatable';
+import { DataTable as MantineDataTable } from 'mantine-datatable';
 import {
   useGetApiEquipment,
   useDeleteApiEquipmentById,

--- a/frontend/src/pages/WorkOrders/WorkOrderInbox.tsx
+++ b/frontend/src/pages/WorkOrders/WorkOrderInbox.tsx
@@ -1,6 +1,6 @@
 import { useState, memo, useMemo, useCallback } from 'react';
 import { Grid, Loader, Center, Stack, TextInput, Select } from '@mantine/core';
-import { MantineDataTable } from '@mantine/datatable';
+import { DataTable as MantineDataTable } from 'mantine-datatable';
 import { useWorkOrders } from '@/modules/workorders/application/useWorkOrders';
 import type { WorkOrder } from '@/modules/workorders/domain/workorder';
 import WorkOrderDetail from './WorkOrderDetail';

--- a/frontend/src/presentation/App.tsx
+++ b/frontend/src/presentation/App.tsx
@@ -1,4 +1,4 @@
-import Router from '../router';
+import Router from '../routes';
 
 const App = () => <Router />;
 


### PR DESCRIPTION
## Summary
- use `../routes` in `<App>` so navigation paths like `/app/*` work
- switch datatable imports to `mantine-datatable`
- add missing `@hookform/resolvers` dependency

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68646fe3b380832ca355ab8c2a7e0595