### PR TITLE
Fix login role redirect and add basic tests

### DIFF
--- a/docs/openapi/reports.yaml
+++ b/docs/openapi/reports.yaml
@@ -3,7 +3,7 @@ info:
   title: Reports API
   version: 1.0.0
 paths:
-  /api/reports/:
+  /api/reports:
     get:
       parameters:
         - in: query

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",

--- a/frontend/src/hooks/useAuth.tsx
+++ b/frontend/src/hooks/useAuth.tsx
@@ -22,7 +22,7 @@ interface AuthContextValue {
   access: string | null;
   refresh: string | null;
   role: Role | null;
-  login: (c: Credentials) => Promise<void>;
+  login: (c: Credentials) => Promise<Role>;
   logout: () => void;
 }
 
@@ -33,11 +33,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [refresh, setRefresh] = useState<string | null>(tokenStore.refresh);
   const [role, setRole] = useState<Role | null>(roleStorage.role);
 
-  const login = useCallback(async (cred: Credentials) => {
+  const login = useCallback(async (cred: Credentials): Promise<Role> => {
     const { access: a, refresh: r, user } = await apiLogin(cred);
     setAccess(a);
     setRefresh(r);
     setRole(user.role);
+    return user.role;
   }, []);
 
   const logout = useCallback(() => {

--- a/frontend/src/presentation/pages/Auth/Login.tsx
+++ b/frontend/src/presentation/pages/Auth/Login.tsx
@@ -15,7 +15,7 @@ const schema = z.object({
 type FormValues = z.infer<typeof schema>;
 
 const Login = () => {
-  const { login, role } = useAuth();
+  const { login } = useAuth();
   const navigate = useNavigate();
   const {
     register,
@@ -29,8 +29,8 @@ const Login = () => {
     setLoading(true);
     setError(null);
     try {
-      await login(data);
-      navigate(getHomeByRole(role), { replace: true });
+      const userRole = await login(data);
+      navigate(getHomeByRole(userRole), { replace: true });
     } catch (err: any) {
       setError('Credenciais inválidas');
     } finally {

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/frontend/src/utils/__tests__/getHomeByRole.test.ts
+++ b/frontend/src/utils/__tests__/getHomeByRole.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { getHomeByRole } from '../getHomeByRole';
+
+describe('getHomeByRole', () => {
+  it('returns dashboard for admin', () => {
+    expect(getHomeByRole('admin')).toBe('/dashboard');
+  });
+
+  it('returns dashboard for manager', () => {
+    expect(getHomeByRole('manager')).toBe('/dashboard');
+  });
+
+  it('returns work-orders path for technician', () => {
+    expect(getHomeByRole('technician')).toBe('/work-orders/my');
+  });
+
+  it('returns dashboard for unknown role', () => {
+    expect(getHomeByRole(null)).toBe('/dashboard');
+  });
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.ts',
+    globals: true,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "dev": "pnpm --filter frontend run dev",
     "build": "pnpm --filter frontend run build",
+    "test": "pnpm --filter frontend run test",
     "api:gen": "openapi-typescript $VITE_API_URL/schema/ -o frontend/src/api/generated/schemas.ts && openapi-typescript-codegen --client axios -o frontend/src/api/generated --useOptions --useUnionTypes $VITE_API_URL/schema/",
     "api:check": "pnpm api:gen && git diff --exit-code",
     "preinstall": "npx only-allow pnpm",


### PR DESCRIPTION
## Summary
- fix path in `reports.yaml`
- return role from `useAuth.login`
- use returned role for navigation in `Login`
- add Vitest config and setup file
- add initial unit tests
- expose `pnpm test` scripts

## Testing
- `pnpm --filter frontend test`
- `VITE_API_URL=https://example.com pnpm run api:gen` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6864726b7194832c9747763c7d83b932