### PR TITLE
Add standardized comments

### DIFF
--- a/frontend/src/api/generated/client.ts
+++ b/frontend/src/api/generated/client.ts
@@ -1,4 +1,4 @@
-// Auto-generated Axios client
+// Cliente Axios gerado automaticamente
 import axios from 'axios';
 
 export const client = axios.create({

--- a/frontend/src/api/generated/schemas.ts
+++ b/frontend/src/api/generated/schemas.ts
@@ -1,4 +1,4 @@
-// Auto-generated via pnpm api:gen
+// Arquivo gerado automaticamente via pnpm api:gen
 export interface ExampleSchema {
   id: number;
 }

--- a/frontend/src/modules/assets/application/useEquipments.ts
+++ b/frontend/src/modules/assets/application/useEquipments.ts
@@ -2,6 +2,13 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import EquipmentService from '../infrastructure/EquipmentService';
 import { EquipmentInput } from '../domain/equipment';
 
+/**
+ * Hook que centraliza as operações de consulta e mutação de equipamentos.
+ */
+
+/**
+ * Interface de acesso aos equipamentos utilizando React Query.
+ */
 export const useEquipments = () => {
   const queryClient = useQueryClient();
   const listQuery = useQuery({

--- a/frontend/src/modules/assets/domain/equipment.ts
+++ b/frontend/src/modules/assets/domain/equipment.ts
@@ -1,10 +1,23 @@
+/**
+ * Representa um equipamento cadastrado no sistema.
+ */
 export interface Equipment {
+  /** Identificador único */
   id: number;
+  /** Nome do equipamento */
   name: string;
+  /** Modelo ou especificação */
   model: string;
+  /** TAG de identificação */
   tag: string;
+  /** Localização física */
   location: string;
+  /** Capacidade térmica em BTUs */
   btus: number;
 }
 
+/**
+ * Estrutura utilizada para criação de equipamentos.
+ * O campo `id` é omitido pois será gerado automaticamente.
+ */
 export type EquipmentInput = Omit<Equipment, 'id'>;

--- a/frontend/src/modules/assets/infrastructure/EquipmentService.ts
+++ b/frontend/src/modules/assets/infrastructure/EquipmentService.ts
@@ -1,5 +1,13 @@
 import { Equipment, EquipmentInput } from '../domain/equipment';
 
+/**
+ * Serviço de persistência de equipamentos.
+ *
+ * Neste estágio os dados são mantidos apenas em memória para fins de
+ * demonstração, simulando o comportamento de uma API real.
+ */
+
+// Conjunto de equipamentos armazenados em memória
 let equipments: Equipment[] = [
   {
     id: 1,
@@ -19,13 +27,17 @@ let equipments: Equipment[] = [
   },
 ];
 
+// Simula uma pequena latência nas requisições
 const delay = () => new Promise((r) => setTimeout(r, 100));
 
+/** Conjunto de operações relacionadas a equipamentos. */
 const EquipmentService = {
+  /** Obtém a lista de equipamentos cadastrados */
   async list(): Promise<Equipment[]> {
     await delay();
     return equipments;
   },
+  /** Cadastra um novo equipamento */
   async create(data: EquipmentInput): Promise<Equipment> {
     await delay();
     const exists = equipments.some((e) => e.tag === data.tag);
@@ -39,6 +51,7 @@ const EquipmentService = {
     equipments.push(newEquipment);
     return newEquipment;
   },
+  /** Atualiza um equipamento existente */
   async update(id: number, data: EquipmentInput): Promise<Equipment> {
     await delay();
     const idx = equipments.findIndex((e) => e.id === id);
@@ -53,6 +66,7 @@ const EquipmentService = {
     equipments[idx] = { id, ...data };
     return equipments[idx];
   },
+  /** Remove um equipamento pelo id */
   async remove(id: number): Promise<void> {
     await delay();
     equipments = equipments.filter((e) => e.id !== id);

--- a/frontend/src/modules/assets/presentation/EquipamentoForm.tsx
+++ b/frontend/src/modules/assets/presentation/EquipamentoForm.tsx
@@ -3,12 +3,23 @@ import { Button, Group, NumberInput, TextInput } from '@mantine/core';
 import { useForm } from 'react-hook-form';
 import { EquipmentFormData, equipmentSchema } from '../schemas/equipmentSchema';
 
+/**
+ * Formulário utilizado para inserir ou editar equipamentos.
+ */
+
+/** Propriedades esperadas pelo formulário de equipamento. */
 interface Props {
+  /** Valores iniciais utilizados em modo de edição */
   initialValues?: EquipmentFormData;
+  /** Função executada no envio */
   onSubmit: (data: EquipmentFormData) => void;
+  /** Função chamada ao cancelar/fechar */
   onCancel: () => void;
 }
 
+/**
+ * Componente de formulário para cadastro e edição de equipamentos.
+ */
 const EquipamentoForm = ({ initialValues, onSubmit, onCancel }: Props) => {
   const {
     register,

--- a/frontend/src/modules/assets/presentation/EquipamentosPage.tsx
+++ b/frontend/src/modules/assets/presentation/EquipamentosPage.tsx
@@ -4,6 +4,11 @@ import { useEquipments } from '../application/useEquipments';
 import EquipamentoForm from './EquipamentoForm';
 import { EquipmentFormData } from '../schemas/equipmentSchema';
 
+/** Tela de listagem e manutenção de equipamentos. */
+
+/**
+ * Página de administração de equipamentos cadastrados.
+ */
 const EquipamentosPage = () => {
   const { data, isLoading, create, update, remove } = useEquipments();
   const [opened, setOpened] = useState(false);
@@ -11,6 +16,9 @@ const EquipamentosPage = () => {
 
   const editingItem = data?.find((e) => e.id === editingId);
 
+  /**
+   * Decide se cria ou atualiza um equipamento no envio do formulário.
+   */
   const handleSubmit = (form: EquipmentFormData) => {
     if (editingId) {
       update.mutate(

--- a/frontend/src/modules/reports/application/useDownloadReport.ts
+++ b/frontend/src/modules/reports/application/useDownloadReport.ts
@@ -4,9 +4,16 @@ import { showNotification } from '@mantine/notifications';
 import { saveAs } from 'file-saver';
 import type { ReportType, ReportFormat } from '../domain/report';
 
+/**
+ * Hook responsável por requisitar a geração e download de relatórios.
+ */
+
 const useDownloadReport = () => {
   const [isFetching, setIsFetching] = useState(false);
 
+  /**
+   * Solicita ao backend o relatório desejado e inicia o download.
+   */
   const download = async (type: ReportType, format: ReportFormat) => {
     const id = `report-${Date.now()}`;
     showNotification({ id, message: 'Gerando relatório…', loading: true });

--- a/frontend/src/modules/reports/domain/report.ts
+++ b/frontend/src/modules/reports/domain/report.ts
@@ -1,2 +1,5 @@
+/** Tipos de relatório disponíveis na aplicação. */
 export type ReportType = 'equipment' | 'workorder';
+
+/** Formatos de arquivo suportados para exportação. */
 export type ReportFormat = 'pdf' | 'xlsx';

--- a/frontend/src/modules/users/application/useUsers.ts
+++ b/frontend/src/modules/users/application/useUsers.ts
@@ -2,7 +2,12 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import UserService from '../infrastructure/UserService';
 import { UserInput } from '../domain/user';
 
-// Hook que centraliza as operações com usuários usando React Query
+/**
+ * Hook que centraliza as operações de consulta e mutação de usuários.
+ *
+ * Utiliza React Query para gerenciar cache e estados de carregamento de forma
+ * consistente em toda a aplicação.
+ */
 
 export const useUsers = () => {
   const queryClient = useQueryClient();

--- a/frontend/src/modules/users/domain/user.ts
+++ b/frontend/src/modules/users/domain/user.ts
@@ -1,16 +1,37 @@
 import { UserRole } from '../schemas/userSchema';
 
+/**
+ * Representa um usuário do sistema.
+ *
+ * Utilizada em toda a aplicação para tipar as entidades vindas da API ou
+ * armazenadas localmente. Segue o padrão definido na camada de domínio
+ * utilizando apenas os campos necessários para as funcionalidades de usuários.
+ */
+
 export interface User {
+  /** Identificador único do usuário */
   id: number;
+  /** Nome completo */
   name: string;
+  /** Endereço de e-mail utilizado para login */
   email: string;
+  /** Papel atribuído ao usuário dentro do sistema */
   role: UserRole;
+  /** Flag indicando se o usuário está ativo */
   active: boolean;
 }
 
+/**
+ * Dados necessários para criar ou atualizar um usuário.
+ * Geralmente provenientes de formulários.
+ */
 export interface UserInput {
+  /** Nome completo */
   name: string;
+  /** Endereço de e-mail */
   email: string;
+  /** Senha em texto plano */
   password: string;
+  /** Papel do usuário */
   role: UserRole;
 }

--- a/frontend/src/modules/users/infrastructure/UserService.ts
+++ b/frontend/src/modules/users/infrastructure/UserService.ts
@@ -1,5 +1,13 @@
 import { User, UserInput } from '../domain/user';
 
+/**
+ * Serviço responsável por manipular usuários na camada de infraestrutura.
+ *
+ * Neste exemplo os dados são mantidos somente em memória, simulando a
+ * comunicação com uma API ou banco de dados real. Cada método possui um pequeno
+ * atraso artificial para imitar chamadas assíncronas.
+ */
+
 // Base de usuários mantida apenas em memória para fins de demonstração
 let users: User[] = [
   {
@@ -25,15 +33,24 @@ let users: User[] = [
   },
 ];
 
+// Simula latência de rede de 100ms
 const delay = () => new Promise((r) => setTimeout(r, 100));
 
+/**
+ * Conjunto de operações disponíveis para lidar com usuários.
+ */
 const UserService = {
-  // Retorna a lista completa de usuários
+  /**
+   * Retorna a lista completa de usuários.
+   */
   async list(): Promise<User[]> {
     await delay();
     return users;
   },
-  // Cria um novo usuário na base local
+  /**
+   * Cria um novo usuário na base local.
+   * Lança erro caso o e-mail informado já esteja em uso.
+   */
   async create(data: UserInput): Promise<User> {
     await delay();
     const exists = users.some((u) => u.email === data.email);
@@ -47,7 +64,10 @@ const UserService = {
     users.push(newUser);
     return newUser;
   },
-  // Atualiza dados de um usuário existente
+  /**
+   * Atualiza dados de um usuário existente.
+   * Também valida se o e-mail informado está disponível.
+   */
   async update(id: number, data: Partial<UserInput>): Promise<User> {
     await delay();
     const idx = users.findIndex((u) => u.id === id);
@@ -64,7 +84,9 @@ const UserService = {
     users[idx] = { ...users[idx], ...data } as User;
     return users[idx];
   },
-  // Ativa ou desativa um usuário
+  /**
+   * Alterna o status ativo/inativo de um usuário.
+   */
   async toggleActive(id: number): Promise<void> {
     await delay();
     const idx = users.findIndex((u) => u.id === id);

--- a/frontend/src/modules/users/presentation/UsuarioForm.tsx
+++ b/frontend/src/modules/users/presentation/UsuarioForm.tsx
@@ -3,12 +3,28 @@ import { Button, Group, PasswordInput, Select, TextInput } from '@mantine/core';
 import { useForm } from 'react-hook-form';
 import { UserFormData, userSchema, roleEnum } from '../schemas/userSchema';
 
+/**
+ * Formulário para criação e edição de usuários.
+ *
+ * Utiliza React Hook Form aliado ao Zod para validação dos campos e exibe os
+ * erros de forma integrada aos componentes do Mantine.
+ */
+
+/**
+ * Propriedades aceitas pelo componente de formulário de usuário.
+ */
 interface Props {
+  /** Valores iniciais utilizados para edição */
   initialValues?: Partial<UserFormData>;
+  /** Callback acionado no envio do formulário */
   onSubmit: (data: UserFormData) => void;
+  /** Callback acionado ao cancelar/fechar */
   onCancel: () => void;
 }
 
+/**
+ * Componente de formulário reutilizável para manutenção de usuários.
+ */
 const UsuarioForm = ({ initialValues, onSubmit, onCancel }: Props) => {
   const {
     register,

--- a/frontend/src/modules/users/presentation/UsuariosPage.tsx
+++ b/frontend/src/modules/users/presentation/UsuariosPage.tsx
@@ -6,6 +6,9 @@ import { useUsers } from '../application/useUsers';
 import UsuarioForm from './UsuarioForm';
 import { UserFormData } from '../schemas/userSchema';
 
+/**
+ * Tela principal de administração de usuários.
+ */
 const UsuariosPage = () => {
   const { data, isLoading, create, update, toggleActive } = useUsers();
   const [opened, setOpened] = useState(false);
@@ -13,7 +16,9 @@ const UsuariosPage = () => {
 
   const editingItem = data?.find((u) => u.id === editingId);
 
-  // Decide se cria ou atualiza um usuário ao enviar o formulário
+  /**
+   * Decide se cria ou atualiza um usuário ao submeter o formulário.
+   */
   const handleSubmit = (form: UserFormData) => {
     if (editingId) {
       update.mutate(

--- a/frontend/src/modules/workorders/application/useWorkOrders.ts
+++ b/frontend/src/modules/workorders/application/useWorkOrders.ts
@@ -6,19 +6,32 @@ import {
   usePatchApiWorkOrdersStatusById,
 } from '@/api/generated/hooks/workOrders';
 
+/**
+ * Hooks utilitários para consulta e manipulação de ordens de serviço.
+ */
+
+/** Parâmetros aceitos ao listar ordens de serviço. */
 export interface WorkOrderQuery {
+  /** Página a ser carregada */
   page: number;
+  /** Texto para busca */
   search?: string;
+  /** Filtro de status */
   status?: string;
+  /** Filtro de prioridade */
   priority?: string;
 }
+/** Consulta lista de ordens de serviço com base nos filtros */
 export const useWorkOrders = (params: WorkOrderQuery) =>
   useGetApiWorkOrders(params);
 
+/** Obtém uma OS específica pelo id */
 export const useWorkOrder = (id: number) => useGetApiWorkOrdersById(id);
 
+/** Lista de possíveis transições de status para uma OS */
 export const useStatusChoices = (id: number) =>
   useGetApiWorkOrdersStatusChoicesById(id);
 
+/** Solicita mudança de status da OS */
 export const useTransitionStatus = (id: number) =>
   usePatchApiWorkOrdersStatusById(id);

--- a/frontend/src/modules/workorders/domain/workorder.ts
+++ b/frontend/src/modules/workorders/domain/workorder.ts
@@ -1,15 +1,28 @@
+/** Possíveis status de uma ordem de serviço */
 export type WorkOrderStatus = 'OPEN' | 'IN_PROGRESS' | 'DONE' | 'CANCELLED';
+
+/** Níveis de prioridade */
 export type WorkOrderPriority = 'LOW' | 'MEDIUM' | 'HIGH';
 
+/**
+ * Estrutura básica de uma ordem de serviço.
+ */
 export interface WorkOrder {
+  /** Identificador da OS */
   id: number;
+  /** Título ou descrição resumida */
   titulo: string;
+  /** Prioridade definida */
   prioridade: WorkOrderPriority;
+  /** Equipamento relacionado */
   equipamento: string;
+  /** Status atual */
   status: WorkOrderStatus;
+  /** Data de abertura no formato ISO */
   dataAbertura: string;
 }
 
+/** Opções de transição de status retornadas pela API */
 export interface StatusChoice {
   label: string;
   value: WorkOrderStatus;

--- a/frontend/src/pages/WorkOrders/WorkOrderDetail.tsx
+++ b/frontend/src/pages/WorkOrders/WorkOrderDetail.tsx
@@ -3,10 +3,17 @@ import { useAuth } from '@/hooks/useAuth';
 import { useWorkOrder } from '@/modules/workorders/application/useWorkOrders';
 import StatusTransitionButtons from './components/StatusTransitionButtons';
 
+/** Exibe os detalhes de uma ordem de serviço selecionada. */
+
+/** Propriedades do componente de detalhes da OS. */
 interface Props {
+  /** Identificador da ordem a ser exibida */
   id: number;
 }
 
+/**
+ * Apresenta informações da OS e botões de transição de status.
+ */
 const WorkOrderDetail = ({ id }: Props) => {
   const { data, isLoading } = useWorkOrder(id);
   const { role } = useAuth();

--- a/frontend/src/pages/WorkOrders/WorkOrderInbox.tsx
+++ b/frontend/src/pages/WorkOrders/WorkOrderInbox.tsx
@@ -5,6 +5,8 @@ import { useWorkOrders } from '@/modules/workorders/application/useWorkOrders';
 import type { WorkOrder } from '@/modules/workorders/domain/workorder';
 import WorkOrderDetail from './WorkOrderDetail';
 
+/** Lista de ordens de serviço com filtros e painel de detalhes. */
+
 const priorities = [
   { value: 'LOW', label: 'Baixa' },
   { value: 'MEDIUM', label: 'Média' },
@@ -18,6 +20,9 @@ const statuses = [
   { value: 'CANCELLED', label: 'Cancelada' },
 ];
 
+/**
+ * Componente que exibe a caixa de entrada de OS com filtros e seleção.
+ */
 const WorkOrderInbox = () => {
   const [page, setPage] = useState(1);
   const [search, setSearch] = useState('');
@@ -46,6 +51,9 @@ const WorkOrderInbox = () => {
     [],
   );
 
+  /**
+   * Seleciona uma OS na tabela para exibir seus detalhes.
+   */
   const handleRowClick = useCallback((record: WorkOrder) => {
     setSelected(record.id);
   }, []);

--- a/frontend/src/pages/WorkOrders/components/StatusTransitionButtons.tsx
+++ b/frontend/src/pages/WorkOrders/components/StatusTransitionButtons.tsx
@@ -5,8 +5,15 @@ import {
   useTransitionStatus,
 } from '@/modules/workorders/application/useWorkOrders';
 
+/**
+ * Botões responsáveis por executar as transições de status da OS.
+ */
+
+/** Propriedades do componente de transição de status */
 interface Props {
+  /** Identificador da OS */
   id: number;
+  /** Papel do usuário atual */
   role: string | null;
 }
 
@@ -16,6 +23,9 @@ const StatusTransitionButtons = ({ id, role }: Props) => {
 
   if (!choices) return null;
 
+  /**
+   * Verifica se o usuário atual pode executar a transição informada.
+   */
   const allowed = (value: string) => {
     if (role === 'admin') return true;
     if (role === 'technician' && value === 'DONE') return true;

--- a/frontend/src/utils/getHomeByRole.ts
+++ b/frontend/src/utils/getHomeByRole.ts
@@ -1,5 +1,12 @@
 import { Role } from '../domain/auth';
 
+/**
+ * Retorna a rota inicial apropriada para o papel informado.
+ */
+
+/**
+ * Mapeia o papel do usuário para a rota padrão correspondente.
+ */
 export function getHomeByRole(role: Role | null | undefined): string {
   switch (role) {
     case 'admin':

--- a/frontend/src/utils/permissions.ts
+++ b/frontend/src/utils/permissions.ts
@@ -1,6 +1,13 @@
 import { useAuth } from '@/hooks/useAuth';
 import type { UserRole } from '@/modules/users/schemas/userSchema';
 
+/**
+ * Verifica se o usuário atual possui permissão para acessar determinado recurso.
+ */
+
+/**
+ * Retorna `true` caso o papel do usuário esteja na lista de papéis permitidos.
+ */
 export function isAuthorized(allowed: UserRole[]): boolean {
   const { role } = useAuth();
   return !!role && allowed.includes(role);

--- a/frontend/src/utils/roleStorage.ts
+++ b/frontend/src/utils/roleStorage.ts
@@ -1,19 +1,19 @@
 import { Role } from '../domain/auth';
 
-// Armazena o papel do usuário selecionado
+/** Armazena o papel do usuário selecionado no localStorage. */
 
 const ROLE_KEY = 'tk_role';
 
 export const roleStorage = {
-  // Obtém o papel salvo
+  /** Obtém o papel salvo */
   get role(): Role | null {
     return localStorage.getItem(ROLE_KEY) as Role | null;
   },
-  // Define o papel no localStorage
+  /** Define o papel no localStorage */
   set(role: Role) {
     localStorage.setItem(ROLE_KEY, role);
   },
-  // Remove o papel armazenado
+  /** Remove o papel armazenado */
   clear() {
     localStorage.removeItem(ROLE_KEY);
   },


### PR DESCRIPTION
## Summary
- document user domain types
- add documentation comments across hooks, services, and components
- document utility modules
- traduzir comentarios gerados

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68647773330c832cba2842a1d496f3b0