### PR TITLE
Add dashboard empty state with CSV import

### DIFF
--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -1,0 +1,4 @@
+import pt from './pt';
+
+const strings = pt; // future: choose locale dynamically
+export default strings;

--- a/frontend/src/i18n/pt.ts
+++ b/frontend/src/i18n/pt.ts
@@ -1,0 +1,11 @@
+const pt = {
+  dashboard: {
+    empty: {
+      title: 'Nenhum equipamento cadastrado',
+      description: 'Importe um arquivo CSV ou adicione manualmente um equipamento.',
+      importCsv: 'Importar CSV',
+      addEquipment: 'Adicionar equipamento',
+    },
+  },
+};
+export default pt;

--- a/frontend/src/pages/Equipment/ImportCsvModal.tsx
+++ b/frontend/src/pages/Equipment/ImportCsvModal.tsx
@@ -1,0 +1,41 @@
+import { Modal, FileInput, Button, Group } from '@mantine/core';
+import { useState } from 'react';
+import { usePostApiEquipmentImport } from '@/api/generated/hooks/equipment';
+
+interface Props {
+  opened: boolean;
+  onClose: () => void;
+}
+
+const ImportCsvModal = ({ opened, onClose }: Props) => {
+  const [file, setFile] = useState<File | null>(null);
+  const importMutation = usePostApiEquipmentImport();
+
+  const handleImport = () => {
+    if (!file) return;
+    const form = new FormData();
+    form.append('file', file);
+    importMutation.mutate(form, { onSuccess: onClose });
+  };
+
+  return (
+    <Modal opened={opened} onClose={onClose} title="Importar CSV">
+      <FileInput
+        label="Arquivo CSV"
+        accept=".csv"
+        value={file}
+        onChange={setFile}
+      />
+      <Group justify="flex-end" mt="md">
+        <Button variant="outline" onClick={onClose} type="button">
+          Cancelar
+        </Button>
+        <Button onClick={handleImport} loading={importMutation.isPending}>
+          Importar
+        </Button>
+      </Group>
+    </Modal>
+  );
+};
+
+export default ImportCsvModal;

--- a/frontend/src/presentation/components/EmptyState.tsx
+++ b/frontend/src/presentation/components/EmptyState.tsx
@@ -1,0 +1,24 @@
+import { Box, Group, Stack, Text } from '@mantine/core';
+import { ReactNode } from 'react';
+
+interface Props {
+  icon?: ReactNode;
+  title: string;
+  description: string;
+  actions?: ReactNode;
+}
+
+const EmptyState = ({ icon, title, description, actions }: Props) => (
+  <Box maw={400} mx="auto" my="xl">
+    <Stack align="center" gap="sm">
+      {icon}
+      <Text fw={700}>{title}</Text>
+      <Text c="dimmed" ta="center">
+        {description}
+      </Text>
+      {actions && <Group mt="md">{actions}</Group>}
+    </Stack>
+  </Box>
+);
+
+export default EmptyState;

--- a/frontend/src/presentation/pages/DashboardPage.tsx
+++ b/frontend/src/presentation/pages/DashboardPage.tsx
@@ -1,4 +1,9 @@
 import { useEffect, useState } from 'react';
+import { Outlet, useNavigate } from 'react-router-dom';
+import { Button } from '@mantine/core';
+import { useGetApiEquipment } from '@/api/generated/hooks/equipment';
+import EmptyState from '../components/EmptyState';
+import strings from '../../i18n';
 
 // Página principal com indicadores do sistema
 import { SimpleGrid, Skeleton, Stack, Title } from '@mantine/core';
@@ -9,12 +14,49 @@ import DashboardService, {
 } from '../../services/DashboardService';
 
 const DashboardPage = () => {
+  const navigate = useNavigate();
+  const { data: equipments, isLoading: eqLoading } = useGetApiEquipment({
+    page: 1,
+    page_size: 1,
+  });
   const [stats, setStats] = useState<DashboardStats | null>(null);
 
   useEffect(() => {
     // Busca os dados do dashboard ao montar o componente
     DashboardService.getStats().then(setStats);
   }, []);
+
+  if (eqLoading || !equipments) {
+    return (
+      <Stack p="lg">
+        <Title order={1}>Dashboard</Title>
+        <Skeleton h={120} />
+      </Stack>
+    );
+  }
+
+  if (equipments.length === 0) {
+    return (
+      <Stack p="lg">
+        <Title order={1}>Dashboard</Title>
+        <EmptyState
+          title={strings.dashboard.empty.title}
+          description={strings.dashboard.empty.description}
+          actions={
+            <>
+              <Button onClick={() => navigate('import-csv')}>
+                {strings.dashboard.empty.importCsv}
+              </Button>
+              <Button variant="outline" onClick={() => navigate('new')}>
+                {strings.dashboard.empty.addEquipment}
+              </Button>
+            </>
+          }
+        />
+        <Outlet />
+      </Stack>
+    );
+  }
 
   // Enquanto os dados não chegam exibimos um loading
   if (!stats) {
@@ -49,6 +91,7 @@ const DashboardPage = () => {
           <div style={{ height: 240 }}>Gráfico Pizza</div>
         </ChartCard>
       </SimpleGrid>
+      <Outlet />
     </Stack>
   );
 };

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -2,6 +2,8 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import AppLayout from '../presentation/components/layout/AppLayout';
 import Overview from '../presentation/pages/Overview';
 import EquipmentList from '../pages/Equipment/EquipmentList';
+import ImportCsvModal from '../pages/Equipment/ImportCsvModal';
+import EquipmentFormModal from '../pages/Equipment/EquipmentFormModal';
 import UsuariosPage from '../modules/users/presentation/UsuariosPage';
 import WorkOrderInbox from '../pages/WorkOrders/WorkOrderInbox';
 import Plans from '../presentation/pages/Plans';
@@ -25,7 +27,11 @@ const Router = () => {
           </AuthGuard>
         }
       >
-        <Route index element={<DashboardPage />} />
+        <Route path="dashboard/*" element={<DashboardPage />}>
+          <Route path="import-csv" element={<ImportCsvModal />} />
+          <Route path="new" element={<EquipmentFormModal />} />
+        </Route>
+        <Route index element={<Navigate to="dashboard" replace />} />
         <Route path="overview" element={<Overview />} />
         <Route path="equipamentos" element={<EquipmentList />} />
         <Route path="usuarios" element={<UsuariosPage />} />


### PR DESCRIPTION
## Summary
- show an EmptyState on Dashboard when no equipment exists
- allow importing CSV or creating equipment via modal routes
- add Mantine EmptyState component and CSV import modal
- basic Portuguese i18n strings
- update routes for modal navigation

## Testing
- `pnpm --filter frontend run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865ec823e40832c88aa7d09d6559173