### PR TITLE
Implement login page with Mantine and tests

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,12 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+const config: StorybookConfig = {
+  stories: ['../frontend/src/**/*.stories.tsx'],
+  addons: [],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {},
+  },
+};
+
+export default config;

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { MantineProvider } from '@mantine/core';
+import '../frontend/src/index.css';
+
+export const decorators = [
+  (Story: any) => (
+    <MantineProvider>
+      <Story />
+    </MantineProvider>
+  ),
+];

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,13 @@
+# Application Architecture
+
+## Login Flow
+
+```mermaid
+flowchart LR
+  UI(Login Page) --> |submit credentials| AuthProvider
+  AuthProvider --> |POST /api/auth/jwt/create/| API
+  API --> |tokens| AuthProvider
+  AuthProvider --> |store tokens & role| UI
+  UI --> |navigate| Dashboard
+```
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "storybook": "storybook dev -p 6006"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.1.1",
@@ -19,6 +20,7 @@
     "@tanstack/react-query": "^5.81.2",
     "@types/file-saver": "^2.0.7",
     "axios": "^1.6.7",
+    "clsx": "^2.1.1",
     "file-saver": "^2.0.5",
     "mantine-datatable": "^8.1.2",
     "papaparse": "^5.4.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       axios:
         specifier: ^1.6.7
         version: 1.10.0
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       file-saver:
         specifier: ^2.0.5
         version: 2.0.5

--- a/frontend/src/components/GradientButton.tsx
+++ b/frontend/src/components/GradientButton.tsx
@@ -1,0 +1,14 @@
+import { Button, type ButtonProps } from '@mantine/core';
+import clsx from 'clsx';
+
+const GradientButton = ({ className, ...props }: ButtonProps) => (
+  <Button
+    {...props}
+    className={clsx(
+      'bg-gradient-to-r from-[#00fff4] to-[#00968f] hover:opacity-90',
+      className,
+    )}
+  />
+);
+
+export default GradientButton;

--- a/frontend/src/components/HeroImage.tsx
+++ b/frontend/src/components/HeroImage.tsx
@@ -1,0 +1,16 @@
+import { Box } from '@mantine/core';
+
+interface Props {
+  image: string;
+}
+
+const HeroImage = ({ image }: Props) => (
+  <Box
+    className="relative h-full w-full bg-cover bg-center bg-no-repeat"
+    style={{ backgroundImage: `url(${image})` }}
+  >
+    <div className="absolute inset-0 bg-black/20" />
+  </Box>
+);
+
+export default HeroImage;

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,2 +1,4 @@
 export * from './Layout';
 export * from './routes';
+export { default as GradientButton } from './GradientButton';
+export { default as HeroImage } from './HeroImage';

--- a/frontend/src/pages/Login/LoginPage.stories.tsx
+++ b/frontend/src/pages/Login/LoginPage.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { MemoryRouter } from 'react-router-dom';
+import LoginPage from './LoginPage';
+
+const meta: Meta<typeof LoginPage> = {
+  title: 'Pages/Login',
+  component: LoginPage,
+  decorators: [(Story) => <MemoryRouter><Story /></MemoryRouter>],
+};
+export default meta;
+
+type Story = StoryObj<typeof LoginPage>;
+
+export const Default: Story = {};
+
+export const WithError: Story = {
+  args: { initialError: 'Credenciais inválidas' },
+};

--- a/frontend/src/pages/Login/LoginPage.test.tsx
+++ b/frontend/src/pages/Login/LoginPage.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import LoginPage from './LoginPage';
+import { AuthProvider } from '@/hooks/useAuth';
+import { MantineProvider } from '@mantine/core';
+
+const server = setupServer(
+  http.post('*/api/auth/login/', async ({ request }) => {
+    const { password } = await request.json();
+    if (password === 'pass1234') {
+      return HttpResponse.json({
+        access: 'a',
+        refresh: 'r',
+        user: { id: 1, email: 'e', name: 'n', role: 'admin' },
+      });
+    }
+    return HttpResponse.text('Invalid', { status: 400 });
+  }),
+);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const navigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return { ...actual, useNavigate: () => navigate };
+});
+
+const renderPage = () =>
+  render(
+    <AuthProvider>
+      <MantineProvider>
+        <MemoryRouter>
+          <LoginPage />
+        </MemoryRouter>
+      </MantineProvider>
+    </AuthProvider>,
+  );
+
+test('successful login redirects', async () => {
+  renderPage();
+  await userEvent.type(screen.getByLabelText(/email/i), 't@e.com');
+  await userEvent.type(screen.getByLabelText(/senha/i), 'pass1234');
+  await userEvent.click(screen.getByRole('button', { name: /acessar/i }));
+  await waitFor(() => expect(navigate).toHaveBeenCalledWith('/dashboard'));
+});
+
+test('invalid credentials show error', async () => {
+  server.use(
+    http.post('*/api/auth/login/', () =>
+      HttpResponse.text('Invalid', { status: 401 }),
+    ),
+  );
+  renderPage();
+  await userEvent.type(screen.getByLabelText(/email/i), 't@e.com');
+  await userEvent.type(screen.getByLabelText(/senha/i), 'wrongpass');
+  await userEvent.click(screen.getByRole('button', { name: /acessar/i }));
+  await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+});

--- a/frontend/src/pages/Login/LoginPage.tsx
+++ b/frontend/src/pages/Login/LoginPage.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react';
+import {
+  Container,
+  SimpleGrid,
+  Paper,
+  Stack,
+  TextInput,
+  PasswordInput,
+  Anchor,
+  Alert,
+} from '@mantine/core';
+import { IconMail, IconLock } from '@tabler/icons-react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '@/hooks/useAuth';
+import GradientButton from '@/components/GradientButton';
+import HeroImage from '@/components/HeroImage';
+
+const schema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+});
+
+export interface LoginPageProps {
+  initialError?: string;
+}
+
+type FormValues = z.infer<typeof schema>;
+
+const LoginPage = ({ initialError }: LoginPageProps) => {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const [formError, setFormError] = useState<string | null>(initialError ?? null);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({ resolver: zodResolver(schema) });
+
+  const onSubmit = async (data: FormValues) => {
+    setFormError(null);
+    try {
+      await login({ username: data.email, password: data.password });
+      navigate('/dashboard');
+    } catch {
+      setFormError('Credenciais inválidas');
+    }
+  };
+
+  return (
+    <Container size="lg" className="flex min-h-screen items-center">
+      <SimpleGrid cols={{ base: 1, lg: 2 }} spacing={0} className="flex-1">
+        <div className="flex flex-col justify-center items-center p-6 md:p-12">
+          <Paper w="100%" maw={400} p="xl" shadow="md">
+            <Stack>
+              <h1 className="text-3xl font-bold text-center mb-6">
+                <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#00fff4] to-[#00968f]">
+                  CLIMA
+                </span>
+                <span className="text-[#00968f]">TRAK</span>
+              </h1>
+              <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+                <TextInput
+                  label="Email"
+                  placeholder="Seu email"
+                  leftSection={<IconMail size={20} />}
+                  {...register('email')}
+                  error={errors.email?.message}
+                />
+                <PasswordInput
+                  label="Senha"
+                  placeholder="Sua senha"
+                  leftSection={<IconLock size={20} />}
+                  {...register('password')}
+                  error={errors.password?.message}
+                />
+                {formError && (
+                  <Alert color="red" title="Erro">
+                    {formError}
+                  </Alert>
+                )}
+                <GradientButton type="submit" fullWidth>
+                  Acessar
+                </GradientButton>
+              </form>
+              <Anchor href="/forgot-password" className="text-sm">
+                Problemas de acesso?
+              </Anchor>
+              <Anchor
+                href="https://help.example.com"
+                target="_blank"
+                rel="noreferrer"
+                className="text-sm self-end"
+              >
+                Central de Ajuda
+              </Anchor>
+            </Stack>
+          </Paper>
+        </div>
+        <div className="hidden lg:block">
+          <HeroImage image="/login-image.png" />
+        </div>
+      </SimpleGrid>
+    </Container>
+  );
+};
+
+export default LoginPage;

--- a/frontend/src/pages/Login/index.ts
+++ b/frontend/src/pages/Login/index.ts
@@ -1,0 +1,1 @@
+export { default } from './LoginPage';

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -11,7 +11,7 @@ const DashboardView = lazy(() => import('./pages/Dashboard/DashboardView'));
 const ReportDownloader = lazy(() => import('./pages/Reports/ReportDownloader'));
 import RoleRoute from './router/RoleRoute';
 const Forbidden = lazy(() => import('./pages/Error/Forbidden'));
-const Login = lazy(() => import('./presentation/pages/Auth/Login'));
+const Login = lazy(() => import('./pages/Login'));
 
 const routes: RouteObject[] = [
   { path: 'login', element: <Login /> },

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -10,7 +10,7 @@ import Plans from '../presentation/pages/Plans';
 import Metrics from '../presentation/pages/Metrics';
 import Reports from '../presentation/pages/Reports';
 import DashboardPage from '../presentation/pages/DashboardPage';
-import LoginPage from '../presentation/pages/LoginPage';
+import LoginPage from '../pages/Login';
 import AuthGuard from '../components/routes/AuthGuard';
 import useIsAuthenticated from '../application/hooks/useIsAuthenticated';
 

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,1 +1,16 @@
 import '@testing-library/jest-dom';
+
+// Polyfill matchMedia for Mantine components
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    media: query,
+    matches: false,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});


### PR DESCRIPTION
## Summary
- add gradient button and hero image components
- create responsive login page with form validation
- document login flow in ARCHITECTURE.md
- add Storybook config and LoginPage stories
- test login page with React Testing Library and MSW

## Testing
- `pnpm test`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_686d557f53dc832cbcd3e09c3f84f597