### PR TITLE
Refactor services error handling

### DIFF
--- a/frontend/src/infrastructure/errors.ts
+++ b/frontend/src/infrastructure/errors.ts
@@ -1,0 +1,9 @@
+export class HttpError extends Error {
+  status?: number;
+
+  constructor(message: string, status?: number) {
+    super(message);
+    this.status = status;
+    Object.setPrototypeOf(this, HttpError.prototype);
+  }
+}

--- a/frontend/src/modules/assets/infrastructure/EquipmentService.ts
+++ b/frontend/src/modules/assets/infrastructure/EquipmentService.ts
@@ -1,4 +1,5 @@
 import { Equipment, EquipmentInput } from '../domain/equipment';
+import { HttpError } from '@/infrastructure/errors';
 
 /**
  * Serviço de persistência de equipamentos.
@@ -42,10 +43,7 @@ const EquipmentService = {
     await delay();
     const exists = equipments.some((e) => e.tag === data.tag);
     if (exists) {
-      const err = new Error('TAG duplicada');
-      // @ts-ignore
-      err.status = 422;
-      throw err;
+      throw new HttpError('TAG duplicada', 422);
     }
     const newEquipment: Equipment = { id: Date.now(), ...data };
     equipments.push(newEquipment);
@@ -58,10 +56,7 @@ const EquipmentService = {
     if (idx === -1) throw new Error('Not found');
     const exists = equipments.some((e) => e.tag === data.tag && e.id !== id);
     if (exists) {
-      const err = new Error('TAG duplicada');
-      // @ts-ignore
-      err.status = 422;
-      throw err;
+      throw new HttpError('TAG duplicada', 422);
     }
     equipments[idx] = { id, ...data };
     return equipments[idx];

--- a/frontend/src/modules/users/infrastructure/UserService.ts
+++ b/frontend/src/modules/users/infrastructure/UserService.ts
@@ -1,4 +1,5 @@
 import { User, UserInput } from '../domain/user';
+import { HttpError } from '@/infrastructure/errors';
 
 /**
  * Serviço responsável por manipular usuários na camada de infraestrutura.
@@ -55,10 +56,7 @@ const UserService = {
     await delay();
     const exists = users.some((u) => u.email === data.email);
     if (exists) {
-      const err = new Error('E-mail já em uso');
-      // @ts-ignore
-      err.status = 422;
-      throw err;
+      throw new HttpError('E-mail já em uso', 422);
     }
     const newUser: User = { id: Date.now(), active: true, ...data };
     users.push(newUser);
@@ -76,10 +74,7 @@ const UserService = {
       data.email &&
       users.some((u) => u.email === data.email && u.id !== id)
     ) {
-      const err = new Error('E-mail já em uso');
-      // @ts-ignore
-      err.status = 422;
-      throw err;
+      throw new HttpError('E-mail já em uso', 422);
     }
     users[idx] = { ...users[idx], ...data } as User;
     return users[idx];


### PR DESCRIPTION
## Summary
- add reusable `HttpError` class for status codes
- refactor `EquipmentService` and `UserService` to throw `HttpError` instead of using `ts-ignore`

## Testing
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686da6a4a7f0832ca500517d08ae4005