### PR TITLE
chore(frontend): update config paths after move

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Build frontend
         run: |
           pnpm install
-          pnpm --filter frontend build
+          pnpm build

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -29,4 +29,4 @@ jobs:
         env:
           NPM_REGISTRY: https://registry.npmmirror.com
       - name: Build frontend
-        run: pnpm --filter frontend build
+        run: pnpm build

--- a/.github/workflows/smoke-front.yml
+++ b/.github/workflows/smoke-front.yml
@@ -3,7 +3,7 @@ name: smoke-front
 on:
   pull_request:
     paths:
-      - 'frontend/**'
+      - '**'
   workflow_dispatch:
 
 jobs:
@@ -18,4 +18,4 @@ jobs:
       - name: Install dependencies
         run: pnpm install --registry ${NPM_REGISTRY:-https://registry.npmmirror.com}
       - name: Build frontend
-        run: pnpm --filter frontend build
+        run: pnpm build

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,7 @@
 import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
-  stories: ['../frontend/src/**/*.stories.tsx'],
+  stories: ['../src/**/*.stories.tsx'],
   addons: [],
   framework: {
     name: '@storybook/react-vite',

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { MantineProvider } from '@mantine/core';
-import '../frontend/src/index.css';
+import '../src/index.css';
 
 export const decorators = [
   (Story: any) => (

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,15 +12,15 @@ WORKDIR /app
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml vite.config.ts tsconfig.json ./
 
 # 2.2) Copia o código-fonte do frontend
-COPY . .        
+COPY . .
 
 
 # 2.3) Instala tudo, com cache BuildKit
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install --frozen-lockfile
 
-# 2.4) Build do Vite dentro de frontend (já traz vite e devDeps)
-WORKDIR /app/frontend
+# 2.4) Build do Vite (já traz vite e devDeps)
+WORKDIR /app
 RUN pnpm run build
 
 # ← STAGE 3: RUNNER
@@ -31,7 +31,7 @@ RUN addgroup -S app && adduser -S app -G app
 USER app
 
 # 3.2) Copia apenas o dist gerado
-COPY --from=builder /app/frontend/dist /usr/share/nginx/html
+COPY --from=builder /app/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ This repository contains the Traknor front‑end (React + Vite) and an optional 
 ## Frontend
 ```bash
 cp .env.example .env   # configure API URL if needed
-cd frontend
 ./setup.sh             # install Node and dependencies
 pnpm dev
 ```
@@ -17,7 +16,6 @@ The app will be available at http://localhost:5173.
 
 To create a production build:
 ```bash
-cd frontend
 pnpm build
 ```
 

--- a/docs/migration/mantine-v8.md
+++ b/docs/migration/mantine-v8.md
@@ -9,7 +9,7 @@ Para facilitar a migração foi criado o codemod `scripts/mantine-v8-appshell-co
 Execute o comando abaixo a partir da raiz do repositório para refatorar automaticamente os arquivos:
 
 ```bash
-npx jscodeshift -t scripts/mantine-v8-appshell-codemod.js frontend/src --extensions=ts,tsx --parser=tsx
+npx jscodeshift -t scripts/mantine-v8-appshell-codemod.js src --extensions=ts,tsx --parser=tsx
 ```
 
 Referência: [Mantine AppShell Guide](https://mantine.dev/guides/app-shell/#compound-components)

--- a/docs/rodando-localmente.md
+++ b/docs/rodando-localmente.md
@@ -27,8 +27,6 @@ pnpm update
 
 ```bash
 pnpm dev
-# Se optar por manter `vite.config.ts` dentro de `frontend`, utilize:
-# vite --config frontend/vite.config.ts
 ```
 
 A aplicação ficará disponível em `http://localhost:5173`.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,2 @@
 packages:
-  - "frontend"
+  - '.'

--- a/run-frontend.sh
+++ b/run-frontend.sh
@@ -2,7 +2,7 @@
 set -e
 
 echo "🗑️  Limpando artefatos antigos..."
-rm -rf node_modules frontend/node_modules dist .vite
+rm -rf node_modules dist .vite
 rm -f package-lock.json pnpm-lock.yaml
 
 echo "🐳  Parando containers antigos e removendo volumes órfãos..."
@@ -26,5 +26,5 @@ echo "🚀  Subindo o frontend em Docker..."
 if ! docker compose up --build -d frontend; then
   docker-compose up --build -d frontend
 fi
-
 echo "✅  Frontend rodando! Acesse http://localhost:3000"
+

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -5,5 +5,5 @@
     "moduleResolution": "Node",
     "allowSyntheticDefaultImports": true
   },
-  "include": ["../vite.config.ts"]
+  "include": ["./vite.config.ts"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,15 +1,13 @@
-// /frontend/vite.config.ts
+// vite.config.ts
 
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 
-// Este arquivo agora vive dentro da pasta /frontend.
-// As configurações são mais simples porque os caminhos são relativos a este local.
+// Configuracao principal do Vite para o projeto React.
 
 export default defineConfig({
-  // A propriedade 'root' foi REMOVIDA. 
-  // O Vite assume, por padrão, a raiz como o diretório atual ('/frontend'), que agora é o correto.
+  // A propriedade 'root' não é definida pois usamos a raiz do projeto.
 
   
   plugins: [react()],
@@ -26,10 +24,9 @@ export default defineConfig({
     },
   },
 
-  // A configuração do alias de caminho agora é muito mais simples.
+  // Resolve path aliases para importações
   resolve: {
     alias: {
-      // Como __dirname agora aponta para /frontend, o caminho para a pasta 'src' está correto e mais limpo.
       '@': path.resolve(__dirname, 'src'),
     },
   },


### PR DESCRIPTION
## Summary
- update storybook config paths
- update Vite config comments after moving files
- fix tsconfig and workspace paths
- simplify GitHub workflows to build from repo root
- adjust Dockerfile and docs
- cleanup run-frontend script

## Testing
- `pnpm install`
- `pnpm dev` *(fails: runs dev server successfully)*

------
https://chatgpt.com/codex/tasks/task_e_686dc112a500832c8f0d037877ee4af2