### PR TITLE
refactor(imports): fix absolute paths in components

### DIFF
--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -4,6 +4,7 @@ import {
   Group,
   AppShell,
   Title,
+  type MantineColorScheme,
 } from '@mantine/core';
 import {
   IconBell,
@@ -15,12 +16,12 @@ import {
 interface Props {
   opened: boolean;
   toggle: () => void;
-  colorScheme: 'light' | 'dark';
+  colorScheme: MantineColorScheme;
   toggleColorScheme: () => void;
 }
 
 const Header = ({ opened, toggle, colorScheme, toggleColorScheme }: Props) => (
-  <AppShell.Header height={64} px="md">
+  <AppShell.Header h={64} px="md">
     <Group h="100%" justify="space-between">
       <Group>
         <Burger

--- a/src/components/Layout/Navbar.tsx
+++ b/src/components/Layout/Navbar.tsx
@@ -23,7 +23,7 @@ const menu = [
 ];
 
 export const Navbar = () => (
-  <AppShell.Navbar width={{ base: 200 }} p="md">
+  <AppShell.Navbar w={{ base: 200 }} p="md">
     <AppShell.Section grow component={Stack} gap="xs">
       {menu.map((item) => (
         <NavLink

--- a/src/components/routes/AuthGuard.tsx
+++ b/src/components/routes/AuthGuard.tsx
@@ -1,6 +1,6 @@
 import { Navigate } from 'react-router-dom';
 import { ReactNode } from 'react';
-import useIsAuthenticated from '../../application/hooks/useIsAuthenticated';
+import useIsAuthenticated from '@/application/hooks/useIsAuthenticated';
 
 interface Props {
   children: ReactNode;

--- a/src/components/routes/PrivateRoute.tsx
+++ b/src/components/routes/PrivateRoute.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 import { Navigate } from 'react-router-dom';
-import { useAuth } from '../../hooks/useAuth';
+import { useAuth } from '@/hooks/useAuth';
 
 interface Props {
   children: ReactNode;


### PR DESCRIPTION
## Summary
- repair relative imports in route components
- fix Mantine typings for Header and Navbar

## Testing
- `pnpm tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_686dc60b7df8832cbc98d2aba5683547