### PR TITLE
Issue 2: remove monorepo leftovers

### DIFF
--- a/legacy/package.json
+++ b/legacy/package.json
@@ -2,16 +2,12 @@
   "name": "traknor-workspace",
   "private": true,
   "packageManager": "pnpm@10.12.2",
-  "workspaces": [
-    "frontend"
-  ],
   "scripts": {
-    "dev": "pnpm --filter frontend run dev",
-    "build": "pnpm --filter frontend run build",
-    "test": "pnpm --filter frontend run test",
-    "api:gen": "openapi-typescript $VITE_API_URL/schema/ -o frontend/src/api/generated/schemas.ts && openapi-typescript-codegen --client axios -o frontend/src/api/generated --useOptions --useUnionTypes $VITE_API_URL/schema/",
-    "api:check": "pnpm api:gen && git diff --exit-code",
-    "preinstall": "npx only-allow pnpm",
+    "dev": "pnpm -C .. run dev",
+    "build": "pnpm -C .. run build",
+    "test": "pnpm -C .. run test",
+    "api:gen": "openapi-typescript $VITE_API_URL/schema/ -o ../src/api/generated/schemas.ts && openapi-typescript-codegen --client axios -o ../src/api/generated --useOptions --useUnionTypes $VITE_API_URL/schema/",
+    "api:check": "pnpm -C .. run api:gen && git diff --exit-code",
     "ci:install": "pnpm install --registry=${NPM_REGISTRY:-https://registry.npmmirror.com}"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- drop `workspaces` and `preinstall` from old package.json
- update scripts to run from project root

## Testing
- `pnpm install --frozen-lockfile`

------
https://chatgpt.com/codex/tasks/task_e_686dcc5ef010832ca62103000a68c687