### PR TITLE
feat(dev): add fake AuthProvider for UI-only mode

### DIFF
--- a/src/contexts/AuthContext.mock.tsx
+++ b/src/contexts/AuthContext.mock.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from 'react';
+import { AuthContext } from '@/hooks/useAuth';
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => (
+  <AuthContext.Provider
+    value={{ access: 'dev', refresh: 'dev', role: 'admin', login: async () => {}, logout: () => {} }}
+  >
+    {children}
+  </AuthContext.Provider>
+);

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -26,7 +26,7 @@ interface AuthContextValue {
   logout: () => void;
 }
 
-const AuthContext = createContext<AuthContextValue | null>(null);
+export const AuthContext = createContext<AuthContextValue | null>(null);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [access, setAccess] = useState<string | null>(tokenStore.access);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,8 +3,11 @@ import ReactDOM from 'react-dom/client';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
 import ClimaTrakThemeProvider from './providers/ClimaTrakThemeProvider';
-import { AuthProvider } from './hooks/useAuth';
+import { AuthProvider as RealAuthProvider } from './hooks/useAuth';
+import { AuthProvider as MockAuthProvider } from './contexts/AuthContext.mock';
 import './index.css';
+
+const AuthProvider = import.meta.env.DEV ? MockAuthProvider : RealAuthProvider;
 
 const queryClient = new QueryClient();
 


### PR DESCRIPTION
## Summary
- create a mock `AuthProvider` for development
- export `AuthContext` for reuse
- use the mock provider in `main.tsx` when running the app in dev mode

## Testing
- `pnpm build`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686dcea50a40832c858369d3c1088bc3