### PR TITLE
Issue 5 - remove Vite proxy

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,17 +12,7 @@ export default defineConfig({
   
   plugins: [react()],
 
-  // A configuração do 'server' continua a mesma para o ambiente de desenvolvimento.
-  server: {
-    proxy: {
-      '/api': {
-        // O alvo do proxy para o backend.
-        target: 'http://localhost:8000',
-        changeOrigin: true,
-        secure: false, // Útil para ambientes de dev com certificados auto-assinados.
-      },
-    },
-  },
+  // O servidor de desenvolvimento não precisa de proxy.
 
   // Resolve path aliases para importações
   resolve: {


### PR DESCRIPTION
## Summary
- remove the `/api` proxy from the Vite dev server configuration

## Testing
- `pnpm install`
- `pnpm dev` (server starts at :5173 without proxy warnings)

------
https://chatgpt.com/codex/tasks/task_e_686dd0a1e340832cb27a5546ebb9467b