### PR TITLE
Issue 9: relax TS build errors and adjust ESLint

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -40,8 +40,6 @@ module.exports = [
     languageOptions: {
       parser: tsParser,
       parserOptions: {
-        project: './tsconfig.eslint.json',
-        tsconfigRootDir: __dirname,
         sourceType: 'module',
         ecmaVersion: 2020,
         ecmaFeatures: { jsx: true },
@@ -116,6 +114,15 @@ module.exports = [
       '*.config.ts',
       'vite.config.ts',
     ],
+    languageOptions: {
+      globals: {
+        window: 'readonly',
+        document: 'readonly',
+        localStorage: 'readonly',
+        module: 'readonly',
+        setTimeout: 'readonly',
+      },
+    },
     files: ['**/*.{js,jsx,ts,tsx,mjs,cjs}'],
   },
 ];

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "echo 'Skipping lint'",
+    "lint:ci": "eslint . --no-config-lookup --config eslint.config.cjs --max-warnings 0",
     "test": "vitest run",
     "storybook": "storybook dev -p 6006"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
       "@/*": ["src/*"]
     },
     "isolatedModules": true,
+    "noEmitOnError": false,
     "noEmit": true,
     "jsx": "react-jsx"
   },


### PR DESCRIPTION
## Summary
- allow build even with TS errors
- update ESLint config to avoid parser project and define globals
- add CI lint script with `--max-warnings 0`

## Testing
- `pnpm lint`
- `pnpm lint:ci` *(fails: max warnings 0)*
- `pnpm test`
- `pnpm build`
- `pnpm dev` *(fails: Command failed after killing)*

------
https://chatgpt.com/codex/tasks/task_e_686dd6cf1cac832cb8a35e77777f28ee