### PR TITLE
docs: add section 'Re-enable backend integration'

### DIFF
--- a/docs/backend-bridge.md
+++ b/docs/backend-bridge.md
@@ -1,0 +1,13 @@
+# Re-enable backend integration
+
+This short guide describes how to connect the application back to the real backend after working in UI-only mode.
+
+## Checklist
+
+1. **Restore Vite proxy** – undo commit `d130b3c9` to bring back the proxy configuration in `vite.config.ts`.
+2. **Swap AuthProvider** – revert commit `e8088384` to use the real authentication context instead of the mock provider.
+3. **Remove MSW mocks** – rollback commit `b0754c94` so network requests hit the backend.
+4. **Reset axios baseURL** – revert commit `3e4f9a11` to read `VITE_API_URL` again.
+5. **Re-enable OpenAPI generator** – revert commit `53cd7753` and run `pnpm -C legacy run api:gen`.
+
+With these changes in place the frontend will talk to the backend as before.


### PR DESCRIPTION
## Summary
- add doc describing how to hook the app back to the real backend

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_686dd9152494832ca8f555025546c1f7